### PR TITLE
feat : DB 구조 및 장소 저장 로직 수정

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -24,7 +24,7 @@ import { ImageModule } from './image/image.module';
         password: process.env.DB_PASSWORD,
         database: process.env.DB_DATABASE,
         entities: [__dirname + '/**/*.entity{.ts,.js}'],
-        autoLoadEntities: true,
+        // autoLoadEntities: true,
         synchronize: true,
         logging: true,
         namingStrategy: new SnakeNamingStrategy(),

--- a/src/category/category.controller.ts
+++ b/src/category/category.controller.ts
@@ -4,8 +4,8 @@ import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { CategoryRes } from './dtos/category-res.dto';
 import { CreateCategoryReqDto } from './dtos/create-category-req.dto';
 
-@ApiTags('category')
-@Controller('category')
+@ApiTags('categories')
+@Controller('categories')
 export class CategoryController {
   constructor(private readonly categoryService: CategoryService) {}
 

--- a/src/entities/insta-guest-collection.entity.ts
+++ b/src/entities/insta-guest-collection.entity.ts
@@ -43,4 +43,7 @@ export class InstaGuestCollection {
 
   @Column({ nullable: true })
   link: string;
+
+  @Column({ nullable: true })
+  embeddedTag: string;
 }

--- a/src/entities/trip-style.entity.ts
+++ b/src/entities/trip-style.entity.ts
@@ -1,7 +1,15 @@
-import { Column, Entity, JoinColumn, OneToOne } from 'typeorm';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 
 @Entity()
 export class TripStyle {
+  @PrimaryGeneratedColumn()
+  id: number;
   //동선 추천을 위한 여행 스타일
   @Column() //숙소 위치
   accomodotionLocation: string;

--- a/src/entities/trip-style.entity.ts
+++ b/src/entities/trip-style.entity.ts
@@ -1,22 +1,10 @@
-import {
-  Column,
-  Entity,
-  JoinColumn,
-  OneToOne,
-  PrimaryGeneratedColumn,
-} from 'typeorm';
-import { User } from './user.entity';
+import { Column, Entity, JoinColumn, OneToOne } from 'typeorm';
 
 @Entity()
-export class Preference {
-  @PrimaryGeneratedColumn()
-  id: number;
-
-  @Column('varchar', { array: true })
-  preferredRegion: string[];
-
-  @Column('varchar', { array: true })
-  preferredCompanion: string[];
+export class TripStyle {
+  //동선 추천을 위한 여행 스타일
+  @Column() //숙소 위치
+  accomodotionLocation: string;
 
   @Column()
   budgetStyle: number; //저렴한~비싼
@@ -36,7 +24,7 @@ export class Preference {
   @Column()
   destinationStyle3: number; //휴양~액티비티
 
-  @OneToOne(() => User, { onDelete: 'CASCADE' })
+  @OneToOne(() => TripStyle, { onDelete: 'CASCADE' })
   @JoinColumn()
-  user: User;
+  trip: TripStyle;
 }

--- a/src/entities/trip-style.entity.ts
+++ b/src/entities/trip-style.entity.ts
@@ -5,6 +5,7 @@ import {
   OneToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+import { Trip } from './trip.entity';
 
 @Entity()
 export class TripStyle {
@@ -32,7 +33,7 @@ export class TripStyle {
   @Column()
   destinationStyle3: number; //휴양~액티비티
 
-  @OneToOne(() => TripStyle, { onDelete: 'CASCADE' })
+  @OneToOne(() => Trip, (trip) => trip.tripStyle, { onDelete: 'CASCADE' })
   @JoinColumn()
-  trip: TripStyle;
+  trip: Trip;
 }

--- a/src/entities/trip.entity.ts
+++ b/src/entities/trip.entity.ts
@@ -3,12 +3,14 @@ import {
   Entity,
   ManyToOne,
   OneToMany,
+  OneToOne,
   PrimaryGeneratedColumn,
   RelationId,
 } from 'typeorm';
 import { PlaceSchedule } from './place-schedule.entity';
 import { AccommodationSchedule } from './accomodation-schedule.entity';
 import { User } from './user.entity';
+import { TripStyle } from './trip-style.entity';
 
 @Entity()
 export class Trip {
@@ -21,17 +23,17 @@ export class Trip {
   @Column({ nullable: true })
   companionCnt: number;
 
+  @Column('varchar', { array: true })
+  companionType: string[];
+
   @Column({ nullable: true })
-  companionType: string;
+  destination: string; //제주, 서울, 강릉, 양양.. 등과 같은
 
   @Column({ nullable: true })
   vehicle: string;
 
-  @Column('varchar', { array: true, nullable: true })
-  styles: string[];
-
-  @Column({ nullable: true })
-  budget: number;
+  @OneToOne(() => TripStyle, (tripStyle) => tripStyle.trip)
+  tripStyle: TripStyle;
 
   @Column()
   startDate: Date;

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -36,6 +36,9 @@ export class User {
   @Column('char', { length: 1 })
   sex: string;
 
+  @Column('varchar', { length: 4 })
+  mbti: string;
+
   @Column({ nullable: true })
   instaGuestUserId: number;
 

--- a/src/image/image.controller.ts
+++ b/src/image/image.controller.ts
@@ -4,8 +4,8 @@ import { ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { CreateImageReqDto } from './dtos/create-image-req.dto';
 import { ImageResDto } from './dtos/image-res.dto';
 
-@ApiTags('image')
-@Controller('image')
+@ApiTags('images')
+@Controller('images')
 export class ImageController {
   constructor(private readonly imageService: ImageService) {}
 

--- a/src/instagram/dto/crawled-instagram-dto.ts
+++ b/src/instagram/dto/crawled-instagram-dto.ts
@@ -17,4 +17,8 @@ export class CrawledInstagramDto {
   @ApiProperty()
   @IsNotEmpty()
   instagramLink: string;
+
+  @ApiProperty()
+  @IsNotEmpty()
+  embeddedTag: string;
 }

--- a/src/instagram/dto/create-insta-guest-collection-dto.ts
+++ b/src/instagram/dto/create-insta-guest-collection-dto.ts
@@ -10,6 +10,9 @@ export class CreateInstaGuestCollectionDto {
   @IsNotEmpty()
   link: string;
 
+  @IsNotEmpty()
+  embeddedTag: string;
+
   @IsOptional()
   content: string;
 }

--- a/src/instagram/instagram.controller.ts
+++ b/src/instagram/instagram.controller.ts
@@ -39,4 +39,19 @@ export class InstagramController {
     //에서는 따로 try catch 하지 않아도 HttpException을 자동으로 받아서 처리해줌.
     return await this.instagramService.crawlToDB(body);
   }
+
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        html: {
+          type: 'string',
+        },
+      },
+    },
+  })
+  @Post('html-test')
+  async htmlTest(@Body('html') htmlBody: string) {
+    return await this.instagramService.htmlTest(htmlBody);
+  }
 }

--- a/src/instagram/instagram.service.ts
+++ b/src/instagram/instagram.service.ts
@@ -37,6 +37,7 @@ export class InstagramService {
             placeId: placeInfo.id,
             link: dto.instagramLink,
             content: dto.instagramDescription,
+            embeddedTag: dto.embeddedTag,
           });
         if (instaGuestCollection) {
           //null값이 아니다 -> 새롭게 저장됐다.
@@ -52,5 +53,9 @@ export class InstagramService {
     }
 
     return createdInstaGuestCollection;
+  }
+
+  htmlTest(htmlBody: string): string {
+    return htmlBody;
   }
 }

--- a/src/place/dtos/place-detail-res.dto.ts
+++ b/src/place/dtos/place-detail-res.dto.ts
@@ -47,11 +47,13 @@ export class PlaceDetailResDto {
   static fromCreation(
     place: Place,
     openHours?: OpenHours,
-    category?: Category,
+    categories?: Category[],
   ): PlaceDetailResDto {
     const placeDetailResDto = new PlaceDetailResDto(place);
     placeDetailResDto.openHours = openHours?.opening || [];
-    placeDetailResDto.categories = category ? [category.categoryName] : [];
+    placeDetailResDto.categories = categories
+      ? categories.map((category) => category.categoryName)
+      : [];
     placeDetailResDto.tags = [];
     placeDetailResDto.images = [];
 

--- a/src/place/place.controller.ts
+++ b/src/place/place.controller.ts
@@ -9,8 +9,8 @@ import {
 } from './dtos/create-place-relation-req.dto';
 import { CreatePlaceReqDto } from './dtos/create-place-req.dto';
 
-@ApiTags('place')
-@Controller('place')
+@ApiTags('places')
+@Controller('places')
 export class PlaceController {
   constructor(private readonly placeService: PlaceService) {}
 
@@ -46,7 +46,7 @@ export class PlaceController {
 
   // Place Relation
   @ApiOperation({ summary: 'Create placeCategory' })
-  @Post('place-category')
+  @Post('place-categories')
   async createPlaceCategory(
     @Body() createPlaceCategoryReqDto: CreatePlaceCategoryReqDto,
   ) {
@@ -56,13 +56,13 @@ export class PlaceController {
   }
 
   @ApiOperation({ summary: 'Create placeTag' })
-  @Post('place-tag')
+  @Post('place-tags')
   async createPlaceTag(@Body() createPlaceTagReqDto: createPlaceTagReqDto) {
     return await this.placeService.createPlaceTag(createPlaceTagReqDto);
   }
 
   @ApiOperation({ summary: 'Create placeImage' })
-  @Post('place-image')
+  @Post('place-images')
   async createPlaceImage(
     @Body() createPlaceImageReqDto: createPlaceImageReqDto,
   ) {

--- a/src/place/place.service.ts
+++ b/src/place/place.service.ts
@@ -69,7 +69,7 @@ export class PlaceService {
       },
     });
 
-    return placeDetail.data;
+    return placeDetail.data; //axios의 반환값에서 data만을 반환시켜야 한다.
   }
 
   @Transactional()
@@ -80,28 +80,26 @@ export class PlaceService {
       where: { googlePlaceId: googlePlaceId },
     });
     if (existedPlace) return this.getPlaceDetailById(existedPlace.id);
-
     const placeDetail = await this.getPlaceDetailByGooglePlaceId(googlePlaceId);
-
     const createdPlace =
       await this.placeRepository.saveByGooglePlaceDetail(placeDetail);
 
     let OpenHours: OpenHours;
-    if (placeDetail.data.regularOpeningHours) {
+    if (placeDetail.regularOpeningHours) {
       OpenHours = await this.openHoursRepository.save({
-        opening: placeDetail.data.regularOpeningHours.weekdayDescriptions,
+        opening: placeDetail.regularOpeningHours.weekdayDescriptions,
         place: createdPlace,
       });
     }
 
-    if (placeDetail.data.addressComponents) {
+    if (placeDetail.addressComponents) {
       await this.addressComponentsRepository.saveAddressComponents(
-        placeDetail.data.addressComponents,
+        placeDetail.addressComponents,
         createdPlace,
       );
     }
     const categories = await this.categoryRepository.saveCategoryArray(
-      placeDetail.data.types,
+      placeDetail.types,
     );
 
     await this.placeCategoryRepository.savePlaceCategoryArray(

--- a/src/place/place.service.ts
+++ b/src/place/place.service.ts
@@ -56,7 +56,6 @@ export class PlaceService {
       },
     );
     return place.data;
-    //return this.getPlaceDetailById(place.data.places[0].id);
   }
 
   async getPlaceDetailByGooglePlaceId(googlePlaceId: string): Promise<any> {
@@ -71,17 +70,6 @@ export class PlaceService {
     });
 
     return placeDetail.data;
-
-    /*return {
-      장소명: placeDetail.data.displayName.text,
-      주소: placeDetail.data.formattedAddress,
-      위도: placeDetail.data.location.latitude,
-      경도: placeDetail.data.location.longitude,
-      전화번호: placeDetail.data.nationalPhoneNumber,
-      영업시간: placeDetail.data.regularOpeningHours.weekdayDescriptions,
-      카테고리: placeDetail.data.primaryTypeDisplayName.text,
-      '기타 태그': placeDetail.data.types,
-    };*/
   }
 
   @Transactional()
@@ -105,21 +93,21 @@ export class PlaceService {
         place: createdPlace,
       });
     }
+
     if (placeDetail.data.addressComponents) {
       await this.addressComponentsRepository.saveAddressComponents(
         placeDetail.data.addressComponents,
         createdPlace,
       );
     }
-
     const categories = await this.categoryRepository.saveCategoryArray(
       placeDetail.data.types,
     );
+
     await this.placeCategoryRepository.savePlaceCategoryArray(
       createdPlace,
       categories,
     );
-    //types를 넘겨받아서, category table에 저장하고, 각 category의 id array 가져오기
 
     return PlaceDetailResDto.fromCreation(createdPlace, OpenHours, categories);
   }

--- a/src/repositories/category.repository.ts
+++ b/src/repositories/category.repository.ts
@@ -9,4 +9,19 @@ export class CategoryRepository extends Repository<Category> {
   constructor(private readonly dataSource: DataSource) {
     super(Category, dataSource.createEntityManager());
   }
+
+  async saveCategoryArray(types: string[]): Promise<Category[]> {
+    const categories: Category[] = [];
+
+    types.map(async (type) => {
+      let category = await this.findOne({ where: { categoryName: type } });
+      if (!category) {
+        category = new Category();
+        category.categoryName = type;
+        category = await this.save({ categoryName: type });
+      }
+      categories.push(category);
+    });
+    return categories;
+  }
 }

--- a/src/repositories/category.repository.ts
+++ b/src/repositories/category.repository.ts
@@ -13,15 +13,17 @@ export class CategoryRepository extends Repository<Category> {
   async saveCategoryArray(types: string[]): Promise<Category[]> {
     const categories: Category[] = [];
 
-    types.map(async (type) => {
-      let category = await this.findOne({ where: { categoryName: type } });
-      if (!category) {
-        category = new Category();
-        category.categoryName = type;
-        category = await this.save({ categoryName: type });
-      }
-      categories.push(category);
-    });
+    await Promise.all(
+      types.map(async (type) => {
+        let category = await this.findOne({ where: { categoryName: type } });
+        if (!category) {
+          category = new Category();
+          category.categoryName = type;
+          category = await this.save({ categoryName: type });
+        }
+        categories.push(category);
+      }),
+    );
     return categories;
   }
 }

--- a/src/repositories/insta-guest-collection.repository.ts
+++ b/src/repositories/insta-guest-collection.repository.ts
@@ -12,7 +12,7 @@ export class InstaGuestCollectionRepository extends Repository<InstaGuestCollect
   async createInstaGuestCollection(
     createInstaGuestCollectionDto: CreateInstaGuestCollectionDto,
   ): Promise<InstaGuestCollection> {
-    //똑같은 인스타 아이디로 똑같은 릴스에 대한 서비스 요청 처리-> 중복 저장 x
+    //한 아이디로 저장한 장소-게시글 쌍에 대한 중복 체크
     const instaGuestCollection = await this.findOne({
       where: {
         instaGuestUserId: createInstaGuestCollectionDto.instaGuestUserId,
@@ -21,7 +21,6 @@ export class InstaGuestCollectionRepository extends Repository<InstaGuestCollect
       },
     });
     if (instaGuestCollection) {
-      //이미 똑같은 장소를 저장한적이 있다면 새롭게 저장하지 않음.
       return null;
     }
     const newInstaGuestCollection = this.create(createInstaGuestCollectionDto);

--- a/src/repositories/place-category.repository.ts
+++ b/src/repositories/place-category.repository.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
+import { Category } from 'src/entities/category.entity';
 import { PlaceCategory } from 'src/entities/place-category.entity';
+import { Place } from 'src/entities/place.entity';
 import { DataSource, Repository } from 'typeorm';
 
 @Injectable()
@@ -8,5 +10,21 @@ export class PlaceCategoryRepository extends Repository<PlaceCategory> {
 
   constructor(private readonly dataSource: DataSource) {
     super(PlaceCategory, dataSource.createEntityManager());
+  }
+
+  async savePlaceCategoryArray(
+    createdPlace: Place,
+    categories: Category[],
+  ): Promise<PlaceCategory[]> {
+    const placeCategories: PlaceCategory[] = [];
+    categories.map(async (category) => {
+      placeCategories.push(
+        await this.save({
+          place: createdPlace,
+          category: category,
+        }),
+      );
+    });
+    return placeCategories;
   }
 }

--- a/src/repositories/place.repository.ts
+++ b/src/repositories/place.repository.ts
@@ -25,12 +25,12 @@ export class PlaceRepository extends Repository<Place> {
 
   async saveByGooglePlaceDetail(placeDetail: any): Promise<Place> {
     return await this.save({
-      name: placeDetail.data.displayName.text,
-      address: placeDetail.data.formattedAddress,
-      latitude: placeDetail.data.location.latitude,
-      longitude: placeDetail.data.location.longitude,
-      googlePlaceId: placeDetail.data.id,
-      phoneNumber: placeDetail.data.nationalPhoneNumber,
+      name: placeDetail.displayName.text,
+      address: placeDetail.formattedAddress,
+      latitude: placeDetail.location.latitude,
+      longitude: placeDetail.location.longitude,
+      googlePlaceId: placeDetail.id,
+      phoneNumber: placeDetail.nationalPhoneNumber,
     });
   }
 }

--- a/src/tag/tag.controller.ts
+++ b/src/tag/tag.controller.ts
@@ -4,8 +4,8 @@ import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { CreateTagReqDto } from './dtos/create-tag-req.dto';
 import { TagResDto } from './dtos/tag-res.dto';
 
-@ApiTags('tag')
-@Controller('tag')
+@ApiTags('tags')
+@Controller('tags')
 export class TagController {
   constructor(private readonly tagService: TagService) {}
 


### PR DESCRIPTION
## Description 
- 크롤링 데이터를 받을 때 embeddedTag를 추가로 받습니다.
- 카테고리는 앞으로 구글 API에서 받아온 모든 카테고리를 저장합니다(이전에는 대표 카테고리 하나만 저장)
- tripStyle 테이블을 추가하고, trip의 budget 칼럼을 tripStyle로 옮겼습니다. trip에 destination 칼럼을 추가했습니다.(제주, 강릉..etc)
- preference 테이블(회원가입때 설정하는 유저 여행 취향)에 들어가는 여행 스타일을 수정했습니다. mbti는 user 테이블로 옮겼습니다.
- api 엔드포인트 네이밍을 약간 수정했습니다(복수형)

## To Discuss
erd 첨부했는데 이해 안되시는 부분 있으면 리뷰로 달아주세용

## Test
<img width="1041" alt="image" src="https://github.com/DevKor-github/IEUM-back/assets/109478362/2383f813-931b-4e3a-aa46-faae77966b22">
크롤링 정상적으로 받아지는거 확인했습니다(태그는 이스케이프 처리)

## ETC
![erd](https://github.com/DevKor-github/IEUM-back/assets/109478362/da89deca-9286-41c3-82e8-32ff460f2f62)


## Related Issues
Related to #9 
