### PR TITLE
feat : Web 지도 조회 로직 수정

### DIFF
--- a/src/common/interfaces/raw-insta-collection.interface.ts
+++ b/src/common/interfaces/raw-insta-collection.interface.ts
@@ -1,5 +1,4 @@
-export interface RawInstaCollectionMarker {
-  insta_guest_collection_id: number;
+export interface RawInstaPlaceMarker {
   place_id: number;
   place_name: string;
   latitude: string;

--- a/src/instagram/dtos/insta-collection-marker.dto.ts
+++ b/src/instagram/dtos/insta-collection-marker.dto.ts
@@ -1,14 +1,10 @@
-import { RawInstaCollectionMarker } from 'src/common/interfaces/raw-insta-collection.interface';
+import { RawInstaPlaceMarker } from 'src/common/interfaces/raw-insta-collection.interface';
 //카테고리, 위도, 경도, 장소 이름, 장소 id(누르면 해당 장소 디테일 볼 수 있게). 마커는 총 갯수
 
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty } from 'class-validator';
 
 export class InstaCollectionMarkerDto {
-  @ApiProperty()
-  @IsNotEmpty()
-  instaGuestCollectionId: number;
-
   @ApiProperty()
   @IsNotEmpty()
   placeId: number;
@@ -33,16 +29,14 @@ export class InstaCollectionMarkerDto {
   representativeCategory: string;
 
   constructor(
-    RawInstaCollectionMarker: RawInstaCollectionMarker,
+    rawInstaPlaceMarker: RawInstaPlaceMarker,
     representativeCategory: string,
   ) {
-    this.instaGuestCollectionId =
-      RawInstaCollectionMarker.insta_guest_collection_id;
-    this.placeId = RawInstaCollectionMarker.place_id;
-    this.placeName = RawInstaCollectionMarker.place_name;
-    this.latitude = parseFloat(RawInstaCollectionMarker.latitude);
-    this.longitude = parseFloat(RawInstaCollectionMarker.longitude);
-    this.category = RawInstaCollectionMarker.primary_category;
+    this.placeId = rawInstaPlaceMarker.place_id;
+    this.placeName = rawInstaPlaceMarker.place_name;
+    this.latitude = parseFloat(rawInstaPlaceMarker.latitude);
+    this.longitude = parseFloat(rawInstaPlaceMarker.longitude);
+    this.category = rawInstaPlaceMarker.primary_category;
     this.representativeCategory = representativeCategory;
   }
 }

--- a/src/instagram/dtos/insta-collection-req-query.dto.ts
+++ b/src/instagram/dtos/insta-collection-req-query.dto.ts
@@ -14,4 +14,7 @@ export class InstaCollectionReqQueryDto {
     example: '부산',
   })
   region: string;
+
+  @ApiProperty({ description: '특정 장소의 ID', required: false })
+  placeId: number;
 }

--- a/src/instagram/instagram.service.ts
+++ b/src/instagram/instagram.service.ts
@@ -116,6 +116,7 @@ export class InstagramService {
         instaGuestUser.id,
         instaCollectionReqQueryDto.region,
         instaCollectionReqQueryDto.cursorId,
+        instaCollectionReqQueryDto.placeId,
       );
     const collectionsList = rawInstaCollections.map((rawCollection) => {
       rawCollection.primary_category = this.translateCategoryName(

--- a/src/instagram/instagram.service.ts
+++ b/src/instagram/instagram.service.ts
@@ -88,7 +88,7 @@ export class InstagramService {
     if (!instaGuestUser) {
       throw new NotFoundException('해당하는 인스타그램 사용자가 없습니다.');
     }
-    const rawMarkers = await this.instaGuestCollectionRepository.getMarkers(
+    const rawMarkers = await this.instaGuestUserRepository.getMarkers(
       instaGuestUser.id,
     );
     const markersList = rawMarkers.map((rawMarker) => {

--- a/src/repositories/insta-guest-collection.repository.ts
+++ b/src/repositories/insta-guest-collection.repository.ts
@@ -40,6 +40,7 @@ export class InstaGuestCollectionRepository extends Repository<InstaGuestCollect
     instaGuestUserId: number,
     region?: string,
     cursorId?: number,
+    placeId?: number,
   ): Promise<RawInstaCollection[]> {
     const query = this.createQueryBuilder('instaGuestCollection')
       .leftJoinAndSelect('instaGuestCollection.place', 'place')
@@ -75,6 +76,12 @@ export class InstaGuestCollectionRepository extends Repository<InstaGuestCollect
           region: `${region}%`,
         },
       ); // 특정 문자열로 시작하는 경우에는 인덱스를 타므로 성능 문제 X
+    }
+
+    if (placeId) {
+      query.andWhere('instaGuestCollection.placeId = :placeId', {
+        placeId,
+      });
     }
 
     if (cursorId) {

--- a/src/repositories/insta-guest-collection.repository.ts
+++ b/src/repositories/insta-guest-collection.repository.ts
@@ -6,7 +6,7 @@ import { INSTA_COLLECTIONS_TAKE } from 'src/common/constants/pagination.constant
 import {
   RawInstaCollection,
   RawInstaCollectionDetail,
-  RawInstaCollectionMarker,
+  RawInstaPlaceMarker,
 } from 'src/common/interfaces/raw-insta-collection.interface';
 
 @Injectable()
@@ -34,27 +34,6 @@ export class InstaGuestCollectionRepository extends Repository<InstaGuestCollect
       newInstaGuestCollection,
     );
     return saveNewInstaGuestCollection;
-  }
-
-  async getMarkers(
-    instaGuestUserId: number,
-  ): Promise<RawInstaCollectionMarker[]> {
-    return await this.createQueryBuilder('instaGuestCollection')
-      .leftJoinAndSelect('instaGuestCollection.place', 'place')
-      .select([
-        'instaGuestCollection.id AS insta_guest_collection_id',
-        'instaGuestCollection.placeId AS place_id',
-        'place.name AS place_name',
-        'place.latitude AS latitude',
-        'place.longitude AS longitude',
-        'place.primaryCategory AS primary_category',
-      ])
-      .where('instaGuestCollection.instaGuestUserId = :instaGuestUserId', {
-        instaGuestUserId,
-      })
-      .groupBy('instaGuestCollection.id')
-      .addGroupBy('place.id')
-      .getRawMany();
   }
 
   async getCollections(

--- a/src/repositories/insta-guest-user.repository.ts
+++ b/src/repositories/insta-guest-user.repository.ts
@@ -1,5 +1,6 @@
 import { InstaGuestUser } from '../entities/insta-guest-user.entity';
 import { Injectable } from '@nestjs/common';
+import { RawInstaPlaceMarker } from 'src/common/interfaces/raw-insta-collection.interface';
 import { CreateInstaGuestUserDto } from 'src/instagram/dtos/create-insta-guest-user-dto';
 import { DataSource, Repository } from 'typeorm';
 
@@ -26,5 +27,25 @@ export class InstaGuestUserRepository extends Repository<InstaGuestUser> {
     newInstaGuestUser.instaId = createInstaGuestUserDto.instaId;
     const saveNewInstaGuestUser = await this.save(newInstaGuestUser);
     return saveNewInstaGuestUser;
+  }
+
+  async getMarkers(instaGuestUserId: number): Promise<RawInstaPlaceMarker[]> {
+    return await this.createQueryBuilder('instaGuestUser')
+      .leftJoinAndSelect('instaGuestUser.instaGuestFolder', 'instaGuestFolder')
+      .leftJoinAndSelect(
+        'instaGuestFolder.instaGuestFolderPlaces',
+        'instaGuestFolderPlaces',
+      )
+      .leftJoinAndSelect('instaGuestFolderPlaces.place', 'place')
+      .select([
+        'place.id AS place_id',
+        'place.name AS place_name',
+        'place.latitude AS latitude',
+        'place.longitude AS longitude',
+        'place.primaryCategory AS primary_category',
+      ])
+      .where('instaGuestUser.id = :instaGuestUserId', { instaGuestUserId })
+      .groupBy('place.id')
+      .getRawMany();
   }
 }


### PR DESCRIPTION
## Description 
- 링크한 Tech Spec에 의해 유저가 장소와 게시글을 저장하는 방식이 수정되었습니다.
    - 이를 기반으로, 웹 지도에서 정보를 조회하는 API인 getMarkers, getCollections, getCollectionDetail의 기능을 수정합니다.

## To Discuss
x

## Test
- getMarkers 실행 결과
![image](https://github.com/DevKor-github/IEUM-back/assets/109478362/03707377-ed84-4e17-8199-6588ec2a519d)

-getCollections 실행 결과(with placeId queryParam)
![image](https://github.com/DevKor-github/IEUM-back/assets/109478362/38da4609-f066-4203-a833-b7b13534c0da)

## ETC
- FE에서는 2가지 변경이 필요합니다(혹시 제가 빼먹은 사항을 발견하시면 말씀해주세요)

- getMarkers가 더 이상 instaGuestCollectionId를 포함하고 있지 않으므로 이를 반영해주셔야 합니다.
- 마커를 클릭했을 때, 이제 getCollectionDetail을 호출하지 않고, 마커의 placeId를 query로 포함하여 getCollections를 호출해주셔야 합니다.


## Related Issues
- #26 
