### PR TITLE
fix : refresh token 인증 에러 해결.

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -36,11 +36,12 @@ export class AuthController {
   })
   //header 값 가져오는 데코레이터
   //header에 authorization 필드가 인증 정보를 가지고 있음.
+  // req.headers.authorization.substring(7),
   renewAccessToken(@Req() req) {
     return this.authService.newAccessToken(
       //passport 인증은 jwt에서 추출한 정보를 user 속성에 담는다!!!
       req.user.id,
-      req.headers.authorization.substring(7),
+      req.user.jti,
     );
   }
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -10,6 +10,7 @@ import { UserRepository } from 'src/repositories/user.repository';
 import { User } from 'src/entities/user.entity';
 import { UserInfoDto } from './dtos/user-info.dto';
 import { NotValidRefreshException } from 'src/common/exceptions/auth.exception';
+import { v4 as uuidv4 } from 'uuid';
 
 @Injectable()
 export class AuthService {
@@ -30,46 +31,29 @@ export class AuthService {
   }
 
   //refreshToken 발급
-  getRefreshToken(user: User) {
-    return this.jwtService.sign(
+  async getRefreshToken(user: User) {
+    //jti를 사용한 refreshToken에 unique id 부여.
+    const jti = uuidv4();
+    const refreshToken = this.jwtService.sign(
       {
         id: user.id,
         oAuthId: user.oAuthId,
+        jti: jti,
       },
       { secret: process.env.SECRET_KEY_REFRESH, expiresIn: '180d' },
     );
-  }
 
-  //refreshToken 암호화
-  async hashRefreshToken(refreshToken: string): Promise<string> {
-    const salt = await bcrypt.genSalt(10); //복잡도 10의 salt를 생성
-    const hashedJwtRefresh = await bcrypt.hash(refreshToken, salt);
+    await this.userRepository.renewRefreshToken(user.oAuthId, jti);
 
-    return hashedJwtRefresh;
-  }
-
-  // RefreshToken이 DB에 저장되어 있는 것과 일치하는지 확인.
-  async compareRefreshToken(
-    refreshToken: string,
-    hashedRefreshToken: string,
-  ): Promise<boolean> {
-    return await bcrypt.compare(refreshToken, hashedRefreshToken);
+    return refreshToken;
   }
 
   //AccessToken 재발급
-  async newAccessToken(id: number, refreshToken: string) {
-    //refreshToken이 해당 유저의 refreshtoken이 맞는지 체크
+  async newAccessToken(id: number, jti: string) {
     const user = await this.userRepository.findUserById(id);
-    console.log({
-      refreshToken: refreshToken,
-      hashedRefresh: user.refreshToken,
-    });
-    const isRefreshTokenMatch = await this.compareRefreshToken(
-      refreshToken,
-      user.refreshToken,
-    );
-    console.log(isRefreshTokenMatch);
 
+    //refreshToken이 해당 유저의 refreshtoken이 맞는지 체크
+    const isRefreshTokenMatch = jti == user.jti;
     if (!isRefreshTokenMatch) {
       throw new NotValidRefreshException();
     }
@@ -88,21 +72,14 @@ export class AuthService {
     //만약 계정이 존재한다면
     if (user) {
       const accessToken = this.getAccessToken(user);
-      const refreshToken = this.getRefreshToken(user);
-      const hashedRefreshToken = await this.hashRefreshToken(refreshToken);
-      //계정이 존재하면 DB 상의 유저 refreshToken만 update
-      await this.userRepository.renewRefreshToken(oAuthId, hashedRefreshToken);
-
-      return UserInfoDto.fromCreation(oAuthId, accessToken, refreshToken);
+      const refreshToken = await this.getRefreshToken(user);
+      return UserInfoDto.fromCreation(user.uuid, accessToken, refreshToken);
     }
 
     //계정이 없다면 새로 추가
     const newUser = await this.userRepository.appleSignIn(oAuthId);
     const accessToken = this.getAccessToken(newUser);
-    const refreshToken = this.getRefreshToken(newUser);
-    const hashedRefreshToken = await this.hashRefreshToken(refreshToken);
-    await this.userRepository.renewRefreshToken(oAuthId, hashedRefreshToken);
-
-    return UserInfoDto.fromCreation(oAuthId, accessToken, refreshToken);
+    const refreshToken = await this.getRefreshToken(newUser);
+    return UserInfoDto.fromCreation(user.uuid, accessToken, refreshToken);
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -55,13 +55,12 @@ export class AuthService {
     //refreshToken이 해당 유저의 refreshtoken이 맞는지 체크
     const isRefreshTokenMatch = jti == user.jti;
     if (!isRefreshTokenMatch) {
-      throw new NotValidRefreshException();
+      throw new NotValidRefreshException('refresh 토큰이 유효하지 않습니다.');
     }
     const newAccessToken = this.getAccessToken(user);
 
     return {
-      message: 'Access Token 재발급 성공',
-      AccessToken: newAccessToken,
+      accessToken: newAccessToken,
     };
   }
 

--- a/src/auth/dtos/user-info.dto.ts
+++ b/src/auth/dtos/user-info.dto.ts
@@ -2,7 +2,7 @@ import { IsBoolean, IsEmail, IsString } from 'class-validator';
 
 export class UserInfoDto {
   @IsString()
-  oAuthId: string;
+  uuid: string;
 
   @IsString()
   accessToken: string;
@@ -14,12 +14,12 @@ export class UserInfoDto {
   initialLogin: boolean;
 
   static fromCreation(
-    oAuthId: string,
+    uuid: string,
     accessToken: string,
     refreshToken: string,
   ): UserInfoDto {
     const dto = new UserInfoDto();
-    dto.oAuthId = oAuthId;
+    dto.uuid = uuid;
     dto.accessToken = accessToken;
     dto.refreshToken = refreshToken;
     return dto;

--- a/src/auth/strategies/jwt-refresh.strategy.ts
+++ b/src/auth/strategies/jwt-refresh.strategy.ts
@@ -14,6 +14,7 @@ export class JwtRefreshStrategy extends PassportStrategy(Strategy, 'refresh') {
     return {
       id: payload.id,
       oAuthId: payload.oAuthId,
+      jti: payload.jti,
     };
   }
 }

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -50,7 +50,7 @@ export class User extends BasicDate {
   instaGuestUser?: InstaGuestUser;
 
   @Column('varchar', { nullable: true })
-  refreshToken: string;
+  jti: string;
 
   @OneToMany(() => Trip, (trip) => trip.user)
   trips: Trip[];

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -24,9 +24,9 @@ export class UserRepository extends Repository<User> {
     await this.softDelete({ id: id });
   }
 
-  async renewRefreshToken(oAuthId: string, refreshToken: string) {
+  async renewRefreshToken(oAuthId: string, jti: string) {
     const user = await this.findUserByAppleOAuthId(oAuthId);
-    user.refreshToken = refreshToken;
+    user.jti = jti;
     return await this.save(user);
   }
 

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -26,7 +26,7 @@ export class UserService {
   async fillUserInfo(firstLoginDto: FirstLoginDto, id: number) {
     const user = await this.userRepository.findUserById(id);
     if (!user) {
-      throw new NotValidUserException();
+      throw new NotValidUserException('해당 유저가 존재하지 않아요.');
     }
     await this.userRepository.fillUserInfo(firstLoginDto, id);
     await this.preferenceRepository.fillUserPreference(
@@ -41,7 +41,7 @@ export class UserService {
   async deleteUser(id: number) {
     const user = await this.userRepository.findUserById(id);
     if (!user) {
-      throw new NotValidUserException('존재하지 않는 계정이에요.');
+      throw new NotValidUserException('해당 유저가 존재하지 않아요.');
     }
     await this.userRepository.softDeleteUser(id);
   }


### PR DESCRIPTION
## Description 

이전에는 refresh token을 salt를 사용한 hash 암호화 하여 db에 저장하는 방식으로 refresh token을 관리하였다. 해당 작업을 통해 db에서 refresh token이 탈취 됐을 때를 대비할 수 있었다. 
__문제 발생__
- 정확히 무슨 문제인지는 밝혀내지 못했으나 이전에 발급 받은 refresh token도 정상 작동하는 문제가 생겼다. bcrypt 과정에서 무슨 문제가 발생하는지 밝혀내지 못했다,

__해결__
- jti를 사용한 refresh token 인증을 하기로 했다. 
- jti란 jwt를 만들 때 uuid등을 생성해 jwt에 유니크한 고유 번호를 주는 것이다. 
- 해쉬된 refresh token을 db에 저장하는 것이 아닌 jti를 db에 저장함으로서 이전에 발급된 refresh token에 대해서는 jti가 일치하지 않게 되어 인증 실패가 된다.
- 또한, refresh token이 아닌 jti만 저장하는 것이기 때문에 탈취도 대비할 수 있다. 

## To Discuss
X

## Test

애플 로그인 성공. 
![image](https://github.com/DevKor-github/IEUM-back/assets/102745492/e2389d1c-850c-4537-97fe-789546360e04)

애플 로그인 2번째 성공.
- refresh token이 새로 발급 됨.
![image](https://github.com/DevKor-github/IEUM-back/assets/102745492/77804508-79f3-472b-b98a-03538d6fcb9c)

이전 refresh token을 사용해서 access token을 발급 받으려 할 시, jti가 일치하지 않아 발급 못 받음.
![image](https://github.com/DevKor-github/IEUM-back/assets/102745492/2b17dda8-cb3d-4744-884d-722981fce66b)

새로운 refresh token 사용시, jti 일치하여 access token을 새로 발급 받을 수 있음.
![image](https://github.com/DevKor-github/IEUM-back/assets/102745492/5f74b220-885e-4863-9ff3-98d6a68d3c71)

## ETC
X

## Related Issues
X
