### PR TITLE
Feature/app/login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "csv-parse": "^5.5.5",
         "csv-parser": "^3.0.0",
         "jsonwebtoken": "^9.0.2",
+        "jwks-rsa": "^3.1.0",
         "jwt-decode": "^4.0.0",
         "multer": "^1.4.5-lts.1",
         "nest-csv-parser": "^2.0.4",
@@ -2464,7 +2465,6 @@
       "version": "9.0.6",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.6.tgz",
       "integrity": "sha512-/5hndP5dCjloafCXns6SZyESp3Ldq7YjH3zwzwczYnjxIT0Fqzk5ROSYVGfFyczIue7IUEj8hkvLbPoLQ18vQw==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -7987,6 +7987,14 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -8196,6 +8204,22 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/jwks-rsa": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-3.1.0.tgz",
+      "integrity": "sha512-v7nqlfezb9YfHHzYII3ef2a2j1XnGeSE/bK3WfumaYCqONAIstJbrEGapz4kadScZzEt7zYCN7bucj8C0Mv/Rg==",
+      "dependencies": {
+        "@types/express": "^4.17.17",
+        "@types/jsonwebtoken": "^9.0.2",
+        "debug": "^4.3.4",
+        "jose": "^4.14.6",
+        "limiter": "^1.1.5",
+        "lru-memoizer": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/jws": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
@@ -8279,6 +8303,11 @@
       "version": "1.10.60",
       "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.60.tgz",
       "integrity": "sha512-Ctgq2lXUpEJo5j1762NOzl2xo7z7pqmVWYai0p07LvAkQ32tbPv3wb+tcUeHEiXhKU5buM4H9MXsXo6OlM6C2g=="
+    },
+    "node_modules/limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -8633,6 +8662,36 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/lru-memoizer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.3.0.tgz",
+      "integrity": "sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "6.0.0"
+      }
+    },
+    "node_modules/lru-memoizer/node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+    },
+    "node_modules/lru-memoizer/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lru-memoizer/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/lru-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "csv-parse": "^5.5.5",
     "csv-parser": "^3.0.0",
     "jsonwebtoken": "^9.0.2",
+    "jwks-rsa": "^3.1.0",
     "jwt-decode": "^4.0.0",
     "multer": "^1.4.5-lts.1",
     "nest-csv-parser": "^2.0.4",

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -57,14 +57,16 @@ export class AuthController {
   }
   //애플에서 유저가 "이메일 변경, 앱 서비스 해지, 애플 계정 탈퇴"를 했을 경우,
   //App ID apple sign in 에서 입력한 Endpoint URL로 유저 정보와 이벤트에 대한 PAYLOAD 데이터를 전송.
-  @Post('/apple-endpoint')
+  @Post('/social/apple-endpoint')
   @ApiOperation({
     summary: '애플 유저 관련 공지 endpoint',
     description:
-      '애플에서 유저가 "이메일 변경, 앱 서비스 해지, 애플 계정 탈퇴"를 했을 경우',
+      '애플에서 유저가 "이메일 수신 중단/활성화, 앱 서비스 해지, 애플 계정 탈퇴"를 했을 경우',
   })
-  async endpoint() {
+  async handleAppleNotification(@Body('payload') payload: string) {
     //추후 논의 후 구현.
+
+    return this.authService.handleAppleNotification(payload);
   }
 
   //카카오, 네이버 회원 탈퇴 시?

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -18,6 +18,7 @@ import {
 } from '@nestjs/swagger';
 import { LoginDto } from './dtos/login.dto';
 import { UserLoginResDto } from './dtos/user-login-res.dto';
+import { AppleNotificationDto } from './dtos/apple-notification.dto';
 
 @Controller('auth')
 @ApiTags('인증/인가 API')
@@ -63,11 +64,13 @@ export class AuthController {
     description:
       '애플에서 유저가 "이메일 수신 중단/활성화, 앱 서비스 해지, 애플 계정 탈퇴"를 했을 경우',
   })
-  async handleAppleNotification(@Body('payload') payload: string) {
-    //추후 논의 후 구현.
-
-    return this.authService.handleAppleNotification(payload);
+  async handleAppleNotification(
+    @Body() appleNotificationDto: AppleNotificationDto,
+  ) {
+    //논의 필요.
+    return this.authService.handleAppleNotification(
+      appleNotificationDto.payload,
+    );
   }
-
-  //카카오, 네이버 회원 탈퇴 시?
+  //카카오, 네이버 회원 정보 수정됐을 시 받는 endpoint
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -17,6 +17,7 @@ import {
   ApiBearerAuth,
 } from '@nestjs/swagger';
 import { LoginDto } from './dtos/login.dto';
+import { UserLoginResDto } from './dtos/user-login-res.dto';
 
 @Controller('auth')
 @ApiTags('인증/인가 API')
@@ -48,7 +49,7 @@ export class AuthController {
     summary: 'social sign in / login',
   })
   @ApiResponse({ status: 201, description: '소셜 로그인 성공' })
-  async socialLogin(@Body() loginDto: LoginDto) {
+  async socialLogin(@Body() loginDto: LoginDto): Promise<UserLoginResDto> {
     return this.authService.socialLogin(
       loginDto.oAuthId,
       loginDto.oAuthPlatform,

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -11,16 +11,12 @@ import {
 import { AuthService } from './auth.service';
 import { AuthGuard } from '@nestjs/passport';
 import {
-  ApiConsumes,
-  ApiBody,
   ApiTags,
   ApiOperation,
-  ApiCreatedResponse,
-  ApiProperty,
   ApiResponse,
   ApiBearerAuth,
 } from '@nestjs/swagger';
-import { AppleLoginDto } from './dtos/apple-login.dto';
+import { LoginDto } from './dtos/login.dto';
 
 @Controller('auth')
 @ApiTags('인증/인가 API')
@@ -45,15 +41,18 @@ export class AuthController {
     );
   }
 
-  // -------------------------- 애플 --------------------------------
-  //애플 로그인
-  @Post('/login/apple')
+  // -------------------------- 소셜 로그인 --------------------------------
+
+  @Post('/login/social')
   @ApiOperation({
-    summary: '애플 sign in',
+    summary: 'social sign in / login',
   })
-  @ApiResponse({ status: 201, description: '애플 로그인 성공' })
-  async appleLogin(@Body() appleLoginDto: AppleLoginDto) {
-    return this.authService.appleLogin(appleLoginDto.oAuthId);
+  @ApiResponse({ status: 201, description: '소셜 로그인 성공' })
+  async socialLogin(@Body() loginDto: LoginDto) {
+    return this.authService.socialLogin(
+      loginDto.oAuthId,
+      loginDto.oAuthPlatform,
+    );
   }
   //애플에서 유저가 "이메일 변경, 앱 서비스 해지, 애플 계정 탈퇴"를 했을 경우,
   //App ID apple sign in 에서 입력한 Endpoint URL로 유저 정보와 이벤트에 대한 PAYLOAD 데이터를 전송.
@@ -66,4 +65,6 @@ export class AuthController {
   async endpoint() {
     //추후 논의 후 구현.
   }
+
+  //카카오, 네이버 회원 탈퇴 시?
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -10,6 +10,9 @@ import { JwtAccessStrategy } from './strategies/jwt-access.strategy';
 import { JwtAccessNicknameCheckStrategy } from './strategies/jwt-access-nickname-check.strategy';
 import { UserService } from 'src/user/user.service';
 import { UserModule } from 'src/user/user.module';
+import { PreferenceRepository } from 'src/repositories/preference.repository';
+import { FolderRepository } from 'src/repositories/folder.repository';
+import { FolderPlaceRepository } from 'src/repositories/folder-place.repository';
 
 @Global()
 @Module({
@@ -26,6 +29,9 @@ import { UserModule } from 'src/user/user.module';
     UserRepository,
     JwtAccessNicknameCheckStrategy,
     UserService,
+    PreferenceRepository,
+    FolderRepository,
+    FolderPlaceRepository,
   ],
   exports: [JwtAccessStrategy, JwtAccessNicknameCheckStrategy],
 })

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -8,10 +8,16 @@ import { JwtModule } from '@nestjs/jwt';
 import { UserRepository } from 'src/repositories/user.repository';
 import { JwtAccessStrategy } from './strategies/jwt-access.strategy';
 import { JwtAccessNicknameCheckStrategy } from './strategies/jwt-access-nickname-check.strategy';
+import { UserService } from 'src/user/user.service';
+import { UserModule } from 'src/user/user.module';
 
 @Global()
 @Module({
-  imports: [TypeOrmModule.forFeature([User]), JwtModule.register({})],
+  imports: [
+    TypeOrmModule.forFeature([User]),
+    JwtModule.register({}),
+    UserModule,
+  ],
   controllers: [AuthController],
   providers: [
     AuthService,
@@ -19,6 +25,7 @@ import { JwtAccessNicknameCheckStrategy } from './strategies/jwt-access-nickname
     JwtRefreshStrategy,
     UserRepository,
     JwtAccessNicknameCheckStrategy,
+    UserService,
   ],
   exports: [JwtAccessStrategy, JwtAccessNicknameCheckStrategy],
 })

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -13,11 +13,29 @@ import { NotValidRefreshException } from 'src/common/exceptions/auth.exception';
 import { v4 as uuidv4 } from 'uuid';
 import { OAuthPlatform } from 'src/common/enums/oAuth-platform.enum';
 import * as jwt from 'jsonwebtoken';
-import { AppleNotificationPayload } from 'src/common/interfaces/apple-notification-jwt-format.interface';
+import * as jwksClient from 'jwks-rsa';
+
+import {
+  AppleNotificationPayload,
+  DecodedToken,
+} from 'src/common/interfaces/apple-notification-jwt-format.interface';
 import { UserService } from 'src/user/user.service';
+import {
+  DefaultBadRequestException,
+  DefaultUndefinedException,
+} from 'src/common/exceptions/default.exception';
+import { json } from 'body-parser';
+import { NotValidUserException } from 'src/common/exceptions/user.exception';
 
 @Injectable()
 export class AuthService {
+  private jwksClientInstance = jwksClient({
+    jwksUri: 'https://appleid.apple.com/auth/keys',
+    cache: true, // 캐시 사용 //서버 메모리에 캐싱되는듯?
+    cacheMaxEntries: 4, // 최대 4개의 키 캐시
+    cacheMaxAge: 600000, // 캐시된 키의 유효 기간 (10분)
+  });
+
   constructor(
     private readonly jwtService: JwtService,
     private readonly userRepository: UserRepository,
@@ -69,7 +87,7 @@ export class AuthService {
     };
   }
 
-  //-------------------------소셜 로그인 ---------------------------
+  //-------------------------소셜 ---------------------------
   async socialLogin(
     oAuthId: string,
     oAuthPlatform: OAuthPlatform,
@@ -106,33 +124,91 @@ export class AuthService {
     );
   }
 
-  async handleAppleNotification(payload: string) {
-    const decodedToken = jwt.decode(payload) as AppleNotificationPayload;
-
-    decodedToken.events.map(async (event) => {
-      switch (event.type) {
-        case 'email-disabled':
-          console.log('email-disabled');
-          break;
-        case 'email-enabled':
-          console.log('email-enabled');
-          break;
-        case 'consent-revoked' || 'account-delete':
-          console.log('유저가 애플 ID 연동을 해제');
-          console.log('유저가 apple ID를 삭제했을 때');
-          const userToDelete =
-            await this.userRepository.findUserByOAuthIdAndPlatform(
-              event.sub,
-              OAuthPlatform.Apple,
-            );
-          if (userToDelete) {
-            await this.userService.deleteUser(userToDelete.id);
-          }
-          break;
-        default:
-          console.log('알 수 없는 요청:' + event.type);
-          break;
-      }
+  private async getAppleSigningKey(kid: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      this.jwksClientInstance.getSigningKey(kid, (err, key) => {
+        if (err) {
+          reject(err); //catch handler로 보냄.
+          return;
+        }
+        const signingKey = key.getPublicKey();
+        resolve(signingKey); //에러 발생 안했을 때의 반환 값.
+      });
     });
+  }
+
+  async handleAppleNotification(payload: string) {
+    const decodedToken = jwt.decode(payload, {
+      complete: true,
+    }) as DecodedToken;
+
+    console.log(decodedToken);
+    const kid = decodedToken.header.kid;
+    let signingKey: string;
+
+    //애플 공개키중 kid 일치하는 키 가져오기.
+    try {
+      signingKey = await this.getAppleSigningKey(kid);
+      console.log(signingKey);
+    } catch (error) {
+      throw new BadRequestException(
+        `kid가 일치하는 공개키 찾을 수 없음: ${error.message}`,
+      );
+      return;
+    }
+
+    //애플 공개키로 받은 jwt 검증하고 type에 따라 다른 처리하기.
+    let type: string;
+    let sub: string;
+    jwt.verify(
+      payload,
+      signingKey,
+      {
+        algorithms: ['RS256'],
+      },
+      (err, decoded) => {
+        if (err) {
+          throw new BadRequestException(`토큰 검증 실패: ${err.message}`);
+          return;
+        }
+        //토큰 검증 됐을 시
+        const jsonEvents = JSON.parse(decodedToken.payload.events);
+        type = jsonEvents.type;
+        sub = jsonEvents.sub;
+        console.log(type);
+        console.log(sub);
+      },
+    );
+
+    switch (type) {
+      case 'email-disabled':
+        console.log('email-disabled');
+        break;
+      case 'email-enabled':
+        console.log('email-enabled');
+        break;
+      case 'consent-revoked':
+        console.log('유저가 애플 ID 연동을 해제');
+      case 'account-delete':
+        console.log('유저가 apple ID를 삭제했을 때');
+        const userToDelete =
+          await this.userRepository.findUserByOAuthIdAndPlatform(
+            sub,
+            OAuthPlatform.Apple,
+          );
+        if (!userToDelete) {
+          throw new NotValidUserException('해당 유저가 존재하지 않습니다.');
+        }
+        await this.userService.deleteUser(userToDelete.id);
+        console.log(`id: ${userToDelete.id} 유저가 회원탈퇴 하였습니다.`);
+        break;
+      default:
+        throw new DefaultUndefinedException(
+          '알 수 없는 값이 애플 서버로부터 들어옴.',
+        );
+        break;
+    }
+
+    return;
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -11,6 +11,7 @@ import { User } from 'src/entities/user.entity';
 import { UserInfoDto } from './dtos/user-info.dto';
 import { NotValidRefreshException } from 'src/common/exceptions/auth.exception';
 import { v4 as uuidv4 } from 'uuid';
+import { OAuthPlatform } from 'src/common/enums/oAuth-platform.enum';
 
 @Injectable()
 export class AuthService {
@@ -43,7 +44,7 @@ export class AuthService {
       { secret: process.env.SECRET_KEY_REFRESH, expiresIn: '180d' },
     );
 
-    await this.userRepository.renewRefreshToken(user.oAuthId, jti);
+    await this.userRepository.renewRefreshToken(user.id, jti);
 
     return refreshToken;
   }
@@ -64,21 +65,37 @@ export class AuthService {
     };
   }
 
-  //-------------------------애플 ---------------------------
-  async appleLogin(oAuthId: string) {
-    const user = await this.userRepository.findUserByAppleOAuthId(oAuthId);
+  //-------------------------소셜 로그인 ---------------------------
+  async socialLogin(oAuthId: string, oAuthPlatform: OAuthPlatform) {
+    const user = await this.userRepository.findUserByOAuthIdAndPlatform(
+      oAuthId,
+      oAuthPlatform,
+    );
 
     //만약 계정이 존재한다면
     if (user) {
       const accessToken = this.getAccessToken(user);
       const refreshToken = await this.getRefreshToken(user);
-      return UserInfoDto.fromCreation(user.uuid, accessToken, refreshToken);
+      return UserInfoDto.fromCreation(
+        user.uuid,
+        user.oAuthPlatform,
+        accessToken,
+        refreshToken,
+      );
     }
 
     //계정이 없다면 새로 추가
-    const newUser = await this.userRepository.appleSignIn(oAuthId);
+    const newUser = await this.userRepository.socialSignIn(
+      oAuthId,
+      oAuthPlatform,
+    );
     const accessToken = this.getAccessToken(newUser);
     const refreshToken = await this.getRefreshToken(newUser);
-    return UserInfoDto.fromCreation(user.uuid, accessToken, refreshToken);
+    return UserInfoDto.fromCreation(
+      newUser.uuid,
+      newUser.oAuthPlatform,
+      accessToken,
+      refreshToken,
+    );
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -101,12 +101,7 @@ export class AuthService {
     if (user) {
       const accessToken = this.getAccessToken(user);
       const refreshToken = await this.getRefreshToken(user);
-      return UserLoginResDto.fromCreation(
-        user.uuid,
-        user.oAuthPlatform,
-        accessToken,
-        refreshToken,
-      );
+      return new UserLoginResDto(user, accessToken, refreshToken);
     }
 
     //계정이 없다면 새로 추가
@@ -116,12 +111,7 @@ export class AuthService {
     );
     const accessToken = this.getAccessToken(newUser);
     const refreshToken = await this.getRefreshToken(newUser);
-    return UserLoginResDto.fromCreation(
-      newUser.uuid,
-      newUser.oAuthPlatform,
-      accessToken,
-      refreshToken,
-    );
+    return new UserLoginResDto(newUser, accessToken, refreshToken);
   }
 
   private async getAppleSigningKey(kid: string): Promise<string> {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -8,7 +8,7 @@ import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
 import { UserRepository } from 'src/repositories/user.repository';
 import { User } from 'src/entities/user.entity';
-import { UserInfoDto } from './dtos/user-info.dto';
+import { UserLoginResDto } from './dtos/user-login-res.dto';
 import { NotValidRefreshException } from 'src/common/exceptions/auth.exception';
 import { v4 as uuidv4 } from 'uuid';
 import { OAuthPlatform } from 'src/common/enums/oAuth-platform.enum';
@@ -66,7 +66,10 @@ export class AuthService {
   }
 
   //-------------------------소셜 로그인 ---------------------------
-  async socialLogin(oAuthId: string, oAuthPlatform: OAuthPlatform) {
+  async socialLogin(
+    oAuthId: string,
+    oAuthPlatform: OAuthPlatform,
+  ): Promise<UserLoginResDto> {
     const user = await this.userRepository.findUserByOAuthIdAndPlatform(
       oAuthId,
       oAuthPlatform,
@@ -76,7 +79,7 @@ export class AuthService {
     if (user) {
       const accessToken = this.getAccessToken(user);
       const refreshToken = await this.getRefreshToken(user);
-      return UserInfoDto.fromCreation(
+      return UserLoginResDto.fromCreation(
         user.uuid,
         user.oAuthPlatform,
         accessToken,
@@ -91,7 +94,7 @@ export class AuthService {
     );
     const accessToken = this.getAccessToken(newUser);
     const refreshToken = await this.getRefreshToken(newUser);
-    return UserInfoDto.fromCreation(
+    return UserLoginResDto.fromCreation(
       newUser.uuid,
       newUser.oAuthPlatform,
       accessToken,

--- a/src/auth/dtos/apple-login.dto.ts
+++ b/src/auth/dtos/apple-login.dto.ts
@@ -1,9 +1,0 @@
-import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
-
-export class AppleLoginDto {
-  @ApiProperty()
-  @IsNotEmpty()
-  @IsString()
-  oAuthId: string;
-}

--- a/src/auth/dtos/apple-notification.dto.ts
+++ b/src/auth/dtos/apple-notification.dto.ts
@@ -1,0 +1,9 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AppleNotificationDto {
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  payload: string;
+}

--- a/src/auth/dtos/login.dto.ts
+++ b/src/auth/dtos/login.dto.ts
@@ -1,0 +1,14 @@
+import { IsEmail, IsEnum, IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { OAuthPlatform } from 'src/common/enums/oAuth-platform.enum';
+
+export class LoginDto {
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  oAuthId: string;
+
+  @ApiProperty({ enum: OAuthPlatform })
+  @IsEnum(OAuthPlatform)
+  oAuthPlatform: OAuthPlatform;
+}

--- a/src/auth/dtos/user-info.dto.ts
+++ b/src/auth/dtos/user-info.dto.ts
@@ -1,4 +1,5 @@
-import { IsBoolean, IsEmail, IsString } from 'class-validator';
+import { IsBoolean, IsEmail, IsEnum, IsString } from 'class-validator';
+import { OAuthPlatform } from 'src/common/enums/oAuth-platform.enum';
 
 export class UserInfoDto {
   @IsString()
@@ -10,16 +11,21 @@ export class UserInfoDto {
   @IsString()
   refreshToken: string;
 
-  @IsBoolean()
-  initialLogin: boolean;
+  @IsEnum(OAuthPlatform)
+  oAuthPlatform: OAuthPlatform;
+
+  // @IsBoolean()
+  // initialLogin: boolean;
 
   static fromCreation(
     uuid: string,
+    oAuthPlatform: OAuthPlatform,
     accessToken: string,
     refreshToken: string,
   ): UserInfoDto {
     const dto = new UserInfoDto();
     dto.uuid = uuid;
+    dto.oAuthPlatform = oAuthPlatform;
     dto.accessToken = accessToken;
     dto.refreshToken = refreshToken;
     return dto;

--- a/src/auth/dtos/user-login-res.dto.ts
+++ b/src/auth/dtos/user-login-res.dto.ts
@@ -1,5 +1,6 @@
 import { IsBoolean, IsEmail, IsEnum, IsString } from 'class-validator';
 import { OAuthPlatform } from 'src/common/enums/oAuth-platform.enum';
+import { User } from 'src/entities/user.entity';
 
 export class UserLoginResDto {
   @IsString()
@@ -14,20 +15,10 @@ export class UserLoginResDto {
   @IsEnum(OAuthPlatform)
   oAuthPlatform: OAuthPlatform;
 
-  // @IsBoolean()
-  // initialLogin: boolean;
-
-  static fromCreation(
-    uuid: string,
-    oAuthPlatform: OAuthPlatform,
-    accessToken: string,
-    refreshToken: string,
-  ): UserLoginResDto {
-    const dto = new UserLoginResDto();
-    dto.uuid = uuid;
-    dto.oAuthPlatform = oAuthPlatform;
-    dto.accessToken = accessToken;
-    dto.refreshToken = refreshToken;
-    return dto;
+  constructor(user: User, accessToken: string, refreshToken: string) {
+    this.uuid = user.uuid;
+    this.oAuthPlatform = user.oAuthPlatform;
+    this.accessToken = accessToken;
+    this.refreshToken = refreshToken;
   }
 }

--- a/src/auth/dtos/user-login-res.dto.ts
+++ b/src/auth/dtos/user-login-res.dto.ts
@@ -1,7 +1,7 @@
 import { IsBoolean, IsEmail, IsEnum, IsString } from 'class-validator';
 import { OAuthPlatform } from 'src/common/enums/oAuth-platform.enum';
 
-export class UserInfoDto {
+export class UserLoginResDto {
   @IsString()
   uuid: string;
 
@@ -22,8 +22,8 @@ export class UserInfoDto {
     oAuthPlatform: OAuthPlatform,
     accessToken: string,
     refreshToken: string,
-  ): UserInfoDto {
-    const dto = new UserInfoDto();
+  ): UserLoginResDto {
+    const dto = new UserLoginResDto();
     dto.uuid = uuid;
     dto.oAuthPlatform = oAuthPlatform;
     dto.accessToken = accessToken;

--- a/src/auth/strategies/jwt-access-nickname-check.strategy.ts
+++ b/src/auth/strategies/jwt-access-nickname-check.strategy.ts
@@ -29,6 +29,7 @@ export class JwtAccessNicknameCheckStrategy extends PassportStrategy(
       );
     }
 
+    console.log(payload.id);
     return {
       id: payload.id,
       oAuthId: payload.oAuthId,

--- a/src/common/enums/error-code.enum.ts
+++ b/src/common/enums/error-code.enum.ts
@@ -18,5 +18,6 @@ export enum ErrorCodeEnum {
   // aa = 90 : Http default exception
   DefaultBadRequest = 9000,
   DefaultUnauthorized = 9001,
+  DefaultForbidden = 9003,
   DefaultUndefined = 9999,
 }

--- a/src/common/exceptions/default.exception.ts
+++ b/src/common/exceptions/default.exception.ts
@@ -24,3 +24,9 @@ export class DefaultInternalServerErrorException extends CustomException {
     super(ErrorCodeEnum.DefaultInternalServerError, message);
   }
 }
+
+export class DefaultForbiddenException extends CustomException {
+  constructor(message?: string) {
+    super(ErrorCodeEnum.DefaultForbidden, message);
+  }
+}

--- a/src/common/filters/custom-exception.filter.ts
+++ b/src/common/filters/custom-exception.filter.ts
@@ -7,6 +7,7 @@ import {
 import { CustomException } from '../exceptions/custom.exception';
 import {
   DefaultBadRequestException,
+  DefaultForbiddenException,
   DefaultInternalServerErrorException,
   DefaultUnauthorizedException,
   DefaultUndefinedException,
@@ -50,6 +51,10 @@ export class CustomExceptionFilter implements ExceptionFilter {
         );
       case 401:
         return new DefaultUnauthorizedException(
+          this.getResponseMessage(exception),
+        );
+      case 403:
+        return new DefaultForbiddenException(
           this.getResponseMessage(exception),
         );
       default:

--- a/src/common/interfaces/apple-notification-jwt-format.interface.ts
+++ b/src/common/interfaces/apple-notification-jwt-format.interface.ts
@@ -1,0 +1,13 @@
+export interface AppleNotificationEvent {
+  type: string;
+  sub: string;
+  event_time: number;
+}
+
+export interface AppleNotificationPayload {
+  iss: string;
+  aud: string;
+  iat: number;
+  jti: string;
+  events: AppleNotificationEvent[];
+}

--- a/src/common/interfaces/apple-notification-jwt-format.interface.ts
+++ b/src/common/interfaces/apple-notification-jwt-format.interface.ts
@@ -1,13 +1,18 @@
-export interface AppleNotificationEvent {
-  type: string;
-  sub: string;
-  event_time: number;
-}
-
 export interface AppleNotificationPayload {
   iss: string;
   aud: string;
   iat: number;
   jti: string;
-  events: AppleNotificationEvent[];
+  events: string;
+}
+
+export interface JwtHeader {
+  alg: string;
+  kid: string;
+}
+
+export interface DecodedToken {
+  header: JwtHeader;
+  payload: AppleNotificationPayload;
+  signature: string;
 }

--- a/src/folder/folder.controller.ts
+++ b/src/folder/folder.controller.ts
@@ -42,7 +42,7 @@ export class FolderController {
   @ApiResponse({ type: FoldersListResDto })
   @Get('/')
   async getFoldersList(@Req() req): Promise<FoldersListResDto> {
-    return await this.folderService.getFoldersList(req.id);
+    return await this.folderService.getFoldersList(req.user.id);
   }
 
   @UseInterceptors(ClassSerializerInterceptor)

--- a/src/folder/folder.controller.ts
+++ b/src/folder/folder.controller.ts
@@ -36,13 +36,13 @@ import { PlacesListResDto } from 'src/place/dtos/paginated-places-list-res.dto';
 export class FolderController {
   constructor(private readonly folderService: FolderService) {}
 
-  @CustomAuthSwaggerDecorator({
-    summary: "Get User's folders list.",
-    type: FoldersListResDto,
-  })
+  @UseGuards(AuthGuard('NCaccess'))
+  @ApiBearerAuth('Access Token')
+  @ApiOperation({ summary: "Get User's folders list." })
+  @ApiResponse({ type: FoldersListResDto })
   @Get('/')
   async getFoldersList(@Req() req): Promise<FoldersListResDto> {
-    return await this.folderService.getFoldersList(1);
+    return await this.folderService.getFoldersList(req.id);
   }
 
   @UseInterceptors(ClassSerializerInterceptor)

--- a/src/repositories/preference.repository.ts
+++ b/src/repositories/preference.repository.ts
@@ -14,6 +14,6 @@ export class PreferenceRepository extends Repository<Preference> {
     const user = new User();
     user.id = id;
     const userPreference = this.create({ ...userPreferenceDto, user });
-    await this.save(userPreference);
+    return await this.save(userPreference);
   }
 }

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { DataSource, Repository } from 'typeorm';
 import { User } from 'src/entities/user.entity';
-import { FirstLoginDto } from 'src/user/dtos/first-login.dto';
+import { FirstLoginReqDto } from 'src/user/dtos/first-login.dto';
 import { OAuthPlatform } from 'src/common/enums/oAuth-platform.enum';
 
 @Injectable()
@@ -12,6 +12,11 @@ export class UserRepository extends Repository<User> {
 
   async findUserById(id: number): Promise<User> {
     const user = this.findOne({ where: { id: id } });
+    return user;
+  }
+
+  async getUserInfoAndPreferenceById(id: number): Promise<User> {
+    const user = this.findOne({ where: { id: id }, relations: ['preference'] });
     return user;
   }
 
@@ -32,13 +37,13 @@ export class UserRepository extends Repository<User> {
     return await this.save(user);
   }
 
-  async fillUserInfo(firstLoginDto: FirstLoginDto, id: number) {
+  async fillUserInfo(firstLoginReqDto: FirstLoginReqDto, id: number) {
     const user = await this.findUserById(id);
 
-    user.nickname = firstLoginDto.nickname;
-    user.birthDate = new Date(firstLoginDto.birthDate);
-    user.sex = firstLoginDto.sex;
-    user.mbti = firstLoginDto.mbti;
+    user.nickname = firstLoginReqDto.nickname;
+    user.birthDate = new Date(firstLoginReqDto.birthDate);
+    user.sex = firstLoginReqDto.sex;
+    user.mbti = firstLoginReqDto.mbti;
 
     return await this.save(user);
   }

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -26,8 +26,8 @@ export class UserRepository extends Repository<User> {
     await this.softDelete({ id: id });
   }
 
-  async renewRefreshToken(oAuthId: string, jti: string) {
-    const user = await this.findUserByAppleOAuthId(oAuthId);
+  async renewRefreshToken(id: number, jti: string) {
+    const user = await this.findUserById(id);
     user.jti = jti;
     return await this.save(user);
   }
@@ -43,18 +43,26 @@ export class UserRepository extends Repository<User> {
     return await this.save(user);
   }
 
-  // ----------------------------애플 --------------------------------
+  // ----------------------------소셜 --------------------------------
 
-  async findUserByAppleOAuthId(authId: string): Promise<User> {
-    const user = this.findOne({ where: { oAuthId: authId } });
+  async findUserByOAuthIdAndPlatform(
+    oAuthId: string,
+    oAuthPlatform: OAuthPlatform,
+  ): Promise<User> {
+    const user = this.findOne({
+      where: { oAuthId: oAuthId, oAuthPlatform: oAuthPlatform },
+    });
     return user;
   }
 
-  async appleSignIn(oAuthId: string): Promise<User> {
+  async socialSignIn(
+    oAuthId: string,
+    oAuthPlatform: OAuthPlatform,
+  ): Promise<User> {
     //로그인 후 앱 자체 회원가입 직후 flow 통한 나머지 field 채워야 함.
     const user = this.create({
       oAuthId: oAuthId,
-      oAuthPlatform: OAuthPlatform.Apple,
+      oAuthPlatform: oAuthPlatform,
     });
     return await this.save(user);
   }

--- a/src/user/dtos/first-login.dto.ts
+++ b/src/user/dtos/first-login.dto.ts
@@ -9,27 +9,37 @@ import {
   IsInt,
   Min,
   Max,
+  IsDateString,
+  MinLength,
+  MaxLength,
+  IsEnum,
 } from 'class-validator';
+import { OAuthPlatform } from 'src/common/enums/oAuth-platform.enum';
+import { User } from 'src/entities/user.entity';
 
-export class FirstLoginDto {
+export class FirstLoginReqDto {
   @ApiProperty()
   @IsNotEmpty()
   @IsString()
   nickname: string;
 
-  @ApiProperty()
+  @ApiProperty({ description: '0000-00-00 format', example: '1999-07-08' })
   @IsNotEmpty()
-  @IsString()
+  @IsDateString() // 0000-00-00형식인지 검증
   birthDate: string;
 
-  @ApiProperty()
+  @ApiProperty({ example: 'M' })
   @IsNotEmpty()
   @IsString()
+  @MinLength(1)
+  @MaxLength(1)
   sex: string;
 
-  @ApiProperty()
+  @ApiProperty({ example: 'ISTJ' })
   @IsNotEmpty()
   @IsString()
+  @MinLength(4)
+  @MaxLength(4)
   mbti: string;
 
   @ApiProperty()
@@ -44,44 +54,44 @@ export class FirstLoginDto {
   @IsString({ each: true })
   preferredCompanion: string[];
 
-  @ApiProperty()
+  @ApiProperty({ example: 1 })
   @IsInt()
   @Min(1)
   @Max(5)
   budgetStyle: number;
 
-  @ApiProperty()
+  @ApiProperty({ example: 1 })
   @IsInt()
   @Min(1)
   @Max(5)
   planningStyle: number;
 
-  @ApiProperty()
+  @ApiProperty({ example: 1 })
   @IsInt()
   @Min(1)
   @Max(5)
   scheduleStyle: number;
 
-  @ApiProperty()
+  @ApiProperty({ example: 1 })
   @IsInt()
   @Min(1)
   @Max(5)
   destinationStyle1: number;
 
-  @ApiProperty()
+  @ApiProperty({ example: 1 })
   @IsInt()
   @Min(1)
   @Max(5)
   destinationStyle2: number;
 
-  @ApiProperty()
+  @ApiProperty({ example: 1 })
   @IsInt()
   @Min(1)
   @Max(5)
   destinationStyle3: number;
 }
 
-export class UserPreferenceDto extends PickType(FirstLoginDto, [
+export class UserPreferenceDto extends PickType(FirstLoginReqDto, [
   'preferredRegion',
   'preferredCompanion',
   'budgetStyle',
@@ -91,15 +101,61 @@ export class UserPreferenceDto extends PickType(FirstLoginDto, [
   'destinationStyle2',
   'destinationStyle3',
 ]) {
-  constructor(firstLoginDto: FirstLoginDto) {
-    super(FirstLoginDto);
-    this.preferredRegion = firstLoginDto.preferredRegion;
-    this.preferredCompanion = firstLoginDto.preferredCompanion;
-    this.budgetStyle = firstLoginDto.budgetStyle;
-    this.planningStyle = firstLoginDto.planningStyle;
-    this.scheduleStyle = firstLoginDto.scheduleStyle;
-    this.destinationStyle1 = firstLoginDto.destinationStyle1;
-    this.destinationStyle2 = firstLoginDto.destinationStyle2;
-    this.destinationStyle3 = firstLoginDto.destinationStyle3;
+  constructor(firstLoginReqDto: FirstLoginReqDto) {
+    super(FirstLoginReqDto);
+    this.preferredRegion = firstLoginReqDto.preferredRegion;
+    this.preferredCompanion = firstLoginReqDto.preferredCompanion;
+    this.budgetStyle = firstLoginReqDto.budgetStyle;
+    this.planningStyle = firstLoginReqDto.planningStyle;
+    this.scheduleStyle = firstLoginReqDto.scheduleStyle;
+    this.destinationStyle1 = firstLoginReqDto.destinationStyle1;
+    this.destinationStyle2 = firstLoginReqDto.destinationStyle2;
+    this.destinationStyle3 = firstLoginReqDto.destinationStyle3;
+  }
+}
+
+export class FirstLoginResDto extends PickType(FirstLoginReqDto, [
+  'nickname',
+  'birthDate',
+  'sex',
+  'mbti',
+  'preferredRegion',
+  'preferredCompanion',
+  'budgetStyle',
+  'planningStyle',
+  'scheduleStyle',
+  'destinationStyle1',
+  'destinationStyle2',
+  'destinationStyle3',
+]) {
+  @ApiProperty()
+  @IsString()
+  uuid: string;
+
+  @ApiProperty()
+  @IsString()
+  oAuthId: string;
+
+  @ApiProperty()
+  @IsEnum(OAuthPlatform)
+  oAuthPlatform: OAuthPlatform;
+
+  constructor(user: User) {
+    super(FirstLoginReqDto);
+    this.uuid = user.uuid;
+    this.oAuthId = user.oAuthId;
+    this.oAuthPlatform = user.oAuthPlatform;
+    this.nickname = user.nickname;
+    this.birthDate = String(user.birthDate);
+    this.sex = user.sex;
+    this.mbti = user.mbti;
+    this.preferredRegion = user.preference.preferredRegion;
+    this.preferredCompanion = user.preference.preferredCompanion;
+    this.budgetStyle = user.preference.budgetStyle;
+    this.planningStyle = user.preference.planningStyle;
+    this.scheduleStyle = user.preference.scheduleStyle;
+    this.destinationStyle1 = user.preference.destinationStyle1;
+    this.destinationStyle2 = user.preference.destinationStyle2;
+    this.destinationStyle3 = user.preference.destinationStyle3;
   }
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -17,7 +17,7 @@ import {
   ApiTags,
   ApiOkResponse,
 } from '@nestjs/swagger';
-import { FirstLoginDto } from './dtos/first-login.dto';
+import { FirstLoginReqDto, FirstLoginResDto } from './dtos/first-login.dto';
 import { UserService } from './user.service';
 
 @ApiTags('유저 API')
@@ -29,13 +29,20 @@ export class UserController {
   @UseGuards(AuthGuard('access'))
   @Put('/me/info')
   @ApiBearerAuth('Access Token')
-  @ApiResponse({ status: 201, description: '유저 정보 입력 성공' })
+  @ApiResponse({
+    status: 201,
+    description: '유저 정보 입력 성공',
+    type: FirstLoginResDto,
+  })
   @ApiOperation({
     summary: '최초 유저 정보 기입',
   })
-  async fillUserInfoAnd(@Body() firstLoginDto: FirstLoginDto, @Req() req) {
+  async fillUserInfoAndPreference(
+    @Body() firstLoginReqDto: FirstLoginReqDto,
+    @Req() req,
+  ): Promise<FirstLoginResDto> {
     return await this.userService.fillUserInfoAndPreference(
-      firstLoginDto,
+      firstLoginReqDto,
       req.user.id,
     );
   }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -33,8 +33,11 @@ export class UserController {
   @ApiOperation({
     summary: '최초 유저 정보 기입',
   })
-  async fillUserInfo(@Body() firstLoginDto: FirstLoginDto, @Req() req) {
-    return await this.userService.fillUserInfo(firstLoginDto, req.user.id);
+  async fillUserInfoAnd(@Body() firstLoginDto: FirstLoginDto, @Req() req) {
+    return await this.userService.fillUserInfoAndPreference(
+      firstLoginDto,
+      req.user.id,
+    );
   }
 
   @UseGuards(AuthGuard('access'))

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,8 +1,11 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { FirstLoginDto } from './dtos/first-login.dto';
+import {
+  FirstLoginReqDto,
+  FirstLoginResDto,
+  UserPreferenceDto,
+} from './dtos/first-login.dto';
 import { UserRepository } from 'src/repositories/user.repository';
 import { PreferenceRepository } from 'src/repositories/preference.repository';
-import { UserPreferenceDto } from './dtos/first-login.dto';
 import { NotValidUserException } from 'src/common/exceptions/user.exception';
 import { FolderRepository } from 'src/repositories/folder.repository';
 import { FolderPlaceRepository } from 'src/repositories/folder-place.repository';
@@ -17,18 +20,22 @@ export class UserService {
   ) {}
 
   //최초 유저 정보 기입
-  async fillUserInfoAndPreference(firstLoginDto: FirstLoginDto, id: number) {
+  async fillUserInfoAndPreference(
+    firstLoginReqDto: FirstLoginReqDto,
+    id: number,
+  ): Promise<FirstLoginResDto> {
     const user = await this.userRepository.findUserById(id);
     if (!user) {
       throw new NotValidUserException('해당 유저가 존재하지 않아요.');
     }
-    await this.userRepository.fillUserInfo(firstLoginDto, id);
+    await this.userRepository.fillUserInfo(firstLoginReqDto, id);
     await this.preferenceRepository.fillUserPreference(
-      new UserPreferenceDto(firstLoginDto),
+      new UserPreferenceDto(firstLoginReqDto),
       id,
     );
-    const createdUser = await this.userRepository.findUserById(id);
-    return createdUser;
+    const createdUser =
+      await this.userRepository.getUserInfoAndPreferenceById(id);
+    return new FirstLoginResDto(createdUser);
   }
 
   //회원탈퇴

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -17,7 +17,7 @@ export class UserService {
   ) {}
 
   //최초 유저 정보 기입
-  async fillUserInfo(firstLoginDto: FirstLoginDto, id: number) {
+  async fillUserInfoAndPreference(firstLoginDto: FirstLoginDto, id: number) {
     const user = await this.userRepository.findUserById(id);
     if (!user) {
       throw new NotValidUserException('해당 유저가 존재하지 않아요.');
@@ -28,7 +28,7 @@ export class UserService {
       id,
     );
     const createdUser = await this.userRepository.findUserById(id);
-    return { message: `${createdUser.nickname}에 대한 최초 정보 기입 성공.` };
+    return createdUser;
   }
 
   //회원탈퇴


### PR DESCRIPTION
## Description 

로그인/회원가입의 경우 잘 작동 되는 것으로 보여 프론트와의 빠른 연동을 위해 가볍게 읽고 문제없으면 일단 merge를 한 후, 추가로 덧붙일 것 나중에 추가하면 될 것 같습니다. 

- 애플, 카카오, 네이버 소셜 로그인/회원가입 가능하도록 수정하였습니다.
- 애플의 server-to-server notification을 받는 url을 현재 https://dev.api.ieum.devkor.club/auth/social/apple-endpoint 로 설정 해두었습니다. 배포 후에는 배포 url로 바꾸면 될 것 같습니다. 
- 카카오, 네이버의 server-to-server notification기능이 있는지는 아직 확인해보지 못했습니다. 

- 회원가입을 완료하지 않았다면 홈탭으로의 이동을 막기 위해 홈탭에서 필수로 부르는 GET /folders에 정보 기입 체크를 하도록 했습니다.

## To Discuss

-애플 로그인을 사용해 이음앱에 가입한 사용자가 애플에서 설정을 변경하면 해당 엔드포인트로 아래와 같은 값을 받아볼 수 있습니다. 
email-disabled : 유저가 이메일 수신을 중단했을 때
email-enabled : 유저가 이메일 수신을 활성화했을 때
consent-revoked : 유저가 Apple ID 연동 해제했을 때
account-delete : 유저가 Apple ID 를 삭제했을 때

이메일 수신 같은 경우엔 아직 기능을 구현하거나 정한 것이 없어 동작하지 않도록 두었고, 유저가 애플 계정을 삭제했거나 애플 계정 연동을 해제하면 이음에서 회원탈퇴되는 로직으로 일단 짜 두었습니다. 

## Test

Post /auth/login/social 
![image](https://github.com/user-attachments/assets/aee9388f-5b67-43bb-8fa4-c93efb39f053)
![image](https://github.com/user-attachments/assets/c57028d5-b393-4648-8576-be8ed24a90fe)

Put /users/me/info 결과 
![image](https://github.com/user-attachments/assets/9a5f7898-556a-449d-a4cb-c22973335086)


유저 정보 기입을 하지 않았을 시, Get /folders 결과 
![image](https://github.com/user-attachments/assets/286a28e0-ea28-4100-a4f4-a50a20ec5aab)


Post /social/apple-endpoint 

- 개인 서버를 통해 해당 엔드포인트로 토큰값이 들어오는 것을 확인했습니다.
- 해당 토큰값을 임의로 사용해 애플 공개키 사용한 검증 및 동작 여부를 확인했습니다. 
실제 사용되는 토큰이라 혹시나 해서 사진 첨부는 안하겠습니다. 


## ETC
참고한 사이트 공유 드립니다.

https://developer.apple.com/documentation/sign_in_with_apple/processing_changes_for_sign_in_with_apple_accounts
https://support.apple.com/en-us/102571

## Related Issues
X
