### PR TITLE
fix : 슬랙 알림 로직 위치 수정

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -33,7 +33,7 @@ import { CrawlingModule } from './crawling/crawling.module';
         entities: [__dirname + '/**/*.entity{.ts,.js}'],
         // autoLoadEntities: true,
         synchronize: true,
-        logging: true,
+        logging: false,
         namingStrategy: new SnakeNamingStrategy(),
       }),
       async dataSourceFactory(options) {

--- a/src/crawling/crawling.module.ts
+++ b/src/crawling/crawling.module.ts
@@ -22,6 +22,14 @@ import { UserModule } from 'src/user/user.module';
           },
           { name: 'ieum_failure', type: 'direct', options: { durable: true } },
         ],
+        queues: [
+          {
+            name: 'failed_queue',
+            options: { durable: true },
+            exchange: 'ieum_failure',
+            routingKey: 'failure',
+          },
+        ],
         prefetchCount: 1,
         connectionInitOptions: { wait: true, timeout: 20000 },
         enableDirectReplyTo: false,


### PR DESCRIPTION
## Description 
원래는 failed_queue를 구독하여 실패한 메세지가 들어오면 그것을 제거하고 알림을 주었지만,
알림을 주는 로직을 더 앞 단으로 옮겨서 슬랙으로 에러 알림을 줌과 동시에, 실패 메세지가 실패 큐에 쌓이도록 만들었습니다.
또한 TypeORM 설정 중 DB Loggin이 다른 에러들을 파악하는 데 방해가 된다고 생각하여 일단은 비활성화 하였네요.

## To Discuss
X

## Test
RabbitMQ와 관련된 서비스는 정상적으로 작동하는 것으로 확인했습니다.

## ETC
X

## Related Issues
X
