### PR TITLE
feat : 유저 프로필 관련 기능 개선

### DIFF
--- a/src/common/enums/preference.enum.ts
+++ b/src/common/enums/preference.enum.ts
@@ -1,0 +1,28 @@
+export enum preferredRegions {
+  SEOUL = '서울',
+  GYEONGGI = '경기',
+  INCHEON = '인천',
+  BUSAN = '부산',
+  DAEGU = '대구',
+  GYEONGBUK = '경북',
+  ULSAN = '울산',
+  GYEONGNAM = '경남',
+  DAEJEON = '대전',
+  CHUNGBUK = '충북',
+  CHUNGNAM = '충남',
+  SEJONG = '세종',
+  GWANGJU = '광주',
+  JEONBUK = '전북',
+  JEONNAM = '전남',
+  JEJU = '제주',
+}
+
+export enum preferredCompanions {
+  ALONE = '나홀로',
+  FAMILY = '가족',
+  PARENTS = '부모님',
+  KIDS = '아이',
+  COUPLE = '연인',
+  FRIENDS = '친구',
+  PETS = '반려동물',
+}

--- a/src/common/enums/preference.enum.ts
+++ b/src/common/enums/preference.enum.ts
@@ -1,4 +1,4 @@
-export enum preferredRegions {
+export enum preferredRegion {
   SEOUL = '서울',
   GYEONGGI = '경기',
   INCHEON = '인천',
@@ -17,7 +17,7 @@ export enum preferredRegions {
   JEJU = '제주',
 }
 
-export enum preferredCompanions {
+export enum preferredCompanion {
   ALONE = '나홀로',
   FAMILY = '가족',
   PARENTS = '부모님',
@@ -25,4 +25,23 @@ export enum preferredCompanions {
   COUPLE = '연인',
   FRIENDS = '친구',
   PETS = '반려동물',
+}
+
+export enum MBTI {
+  ISTJ = 'ISTJ',
+  ISFJ = 'ISFJ',
+  INFJ = 'INFJ',
+  INTJ = 'INTJ',
+  ISTP = 'ISTP',
+  ISFP = 'ISFP',
+  INFP = 'INFP',
+  INTP = 'INTP',
+  ESTP = 'ESTP',
+  ESFP = 'ESFP',
+  ENFP = 'ENFP',
+  ENTP = 'ENTP',
+  ESTJ = 'ESTJ',
+  ESFJ = 'ESFJ',
+  ENFJ = 'ENFJ',
+  ENTJ = 'ENTJ',
 }

--- a/src/common/enums/preference.enum.ts
+++ b/src/common/enums/preference.enum.ts
@@ -15,6 +15,7 @@ export enum preferredRegion {
   JEONBUK = '전북',
   JEONNAM = '전남',
   JEJU = '제주',
+  GANGWON = '강원',
 }
 
 export enum preferredCompanion {

--- a/src/common/utils/exception.util.ts
+++ b/src/common/utils/exception.util.ts
@@ -92,6 +92,12 @@ export const ieumExceptions = {
     errorCode: 1013,
     statusCode: 400,
   },
+  DUPLICATED_NICKNAME: {
+    name: 'DUPLICATED_NICKNAME',
+    message: '중복된 닉네임이에요.',
+    errorCode: 1014,
+    statusCode: 409,
+  },
   //102x : Kakao
   KAKAO_ACCESS_TOKEN_VERIFICATION_FAILED: {
     name: 'KAKAO_ACCESS_TOKEN_VERIFICATION_FAILED',

--- a/src/user/dtos/first-login.dto.ts
+++ b/src/user/dtos/first-login.dto.ts
@@ -1,10 +1,8 @@
-import { ApiProperty, PickType } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 import {
   IsBoolean,
-  IsEmail,
   IsNotEmpty,
   IsString,
-  IsDate,
   IsArray,
   IsInt,
   Min,
@@ -14,156 +12,118 @@ import {
   MaxLength,
   IsEnum,
   IsOptional,
+  IsIn,
 } from 'class-validator';
-import { OAuthPlatform } from 'src/common/enums/oAuth-platform.enum';
-import { User } from '../entities/user.entity';
+import {
+  MBTI,
+  preferredCompanion,
+  preferredRegion,
+} from 'src/common/enums/preference.enum';
 
 export class FirstLoginReqDto {
-  @ApiProperty({ nullable: true })
+  @ApiProperty({ description: '광고 동의 여부', nullable: true })
   @IsBoolean()
   @IsOptional()
   isAdConfirmed?: boolean;
 
-  @ApiProperty()
+  @ApiProperty({ description: '닉네임', example: '닉네임' })
   @IsNotEmpty()
   @IsString()
   nickname: string;
 
-  @ApiProperty({ description: '0000-00-00 format', example: '1999-07-08' })
+  @ApiProperty({ description: '생년월일', example: '1999-07-08' })
   @IsNotEmpty()
   @IsDateString() // 0000-00-00형식인지 검증
   birthDate: string;
 
-  @ApiProperty({ example: 'M' })
+  @ApiProperty({ description: '성별. M or F', example: 'M' })
   @IsNotEmpty()
   @IsString()
   @MinLength(1)
   @MaxLength(1)
+  @IsIn(['M', 'F'])
   sex: string;
 
-  @ApiProperty({ example: 'ISTJ' })
+  @ApiProperty({ description: 'MBTI', example: 'ISTJ' })
   @IsNotEmpty()
   @IsString()
   @MinLength(4)
   @MaxLength(4)
-  mbti: string;
+  @IsEnum(MBTI)
+  mbti: MBTI;
 
-  @ApiProperty()
+  @ApiProperty({
+    enum: preferredRegion,
+    description:
+      '선호 지역들을 전달. 하나로 묶여있는 지역이라도 각각 따로 보내주세요',
+    example: ['충북', '충남', '대전', '경남', '울산'],
+  })
   @IsNotEmpty()
   @IsArray()
-  @IsString({ each: true })
-  preferredRegion: string[];
+  @IsEnum(preferredRegion, { each: true })
+  preferredRegions: preferredRegion[];
 
-  @ApiProperty()
+  @ApiProperty({
+    enum: preferredCompanion,
+    description: '선호 동반자를 대문자 String으로 전달.',
+    example: ['나홀로', '친구'],
+  })
   @IsNotEmpty()
   @IsArray()
-  @IsString({ each: true })
-  preferredCompanion: string[];
+  @IsEnum(preferredCompanion, { each: true })
+  preferredCompanions: preferredCompanion[];
 
-  @ApiProperty({ example: 1 })
+  @ApiProperty({
+    example: 1,
+    description: '저렴한 여행지 ~ 비싼 여행지. 1~5로 입력',
+  })
   @IsInt()
   @Min(1)
   @Max(5)
-  budgetStyle: number;
+  cheapOrExpensive: number;
 
-  @ApiProperty({ example: 1 })
+  @ApiProperty({
+    example: 1,
+    description: '계획적인 여행 ~ 즉흥적인 여행. 1~5로 입력',
+  })
   @IsInt()
   @Min(1)
   @Max(5)
-  planningStyle: number;
+  plannedOrImprovise: number;
 
-  @ApiProperty({ example: 1 })
+  @ApiProperty({
+    example: 1,
+    description: '알차게 여행 ~ 여유롭게 여행. 1~5로 입력',
+  })
   @IsInt()
   @Min(1)
   @Max(5)
-  scheduleStyle: number;
+  tightOrLoose: number;
 
-  @ApiProperty({ example: 1 })
+  @ApiProperty({
+    example: 1,
+    description: '인기있는 여행지 ~ 로컬 여행지. 1~5로 입력',
+  })
   @IsInt()
   @Min(1)
   @Max(5)
-  destinationStyle1: number;
+  popularOrLocal: number;
 
-  @ApiProperty({ example: 1 })
+  @ApiProperty({
+    example: 1,
+    description: '자연적인 여행지 ~ 도시적인 여행지. 1~5로 입력',
+  })
   @IsInt()
   @Min(1)
   @Max(5)
-  destinationStyle2: number;
+  natureOrCity: number;
 
-  @ApiProperty({ example: 1 })
+  @ApiProperty({
+    example: 1,
+    description: '휴양 여행 ~ 액티비티 여행. 1~5로 입력',
+  })
   @IsInt()
   @Min(1)
   @Max(5)
-  destinationStyle3: number;
-}
-
-export class UserPreferenceDto extends PickType(FirstLoginReqDto, [
-  'preferredRegion',
-  'preferredCompanion',
-  'budgetStyle',
-  'planningStyle',
-  'scheduleStyle',
-  'destinationStyle1',
-  'destinationStyle2',
-  'destinationStyle3',
-]) {
-  constructor(firstLoginReqDto: FirstLoginReqDto) {
-    super(FirstLoginReqDto);
-    this.preferredRegion = firstLoginReqDto.preferredRegion;
-    this.preferredCompanion = firstLoginReqDto.preferredCompanion;
-    this.budgetStyle = firstLoginReqDto.budgetStyle;
-    this.planningStyle = firstLoginReqDto.planningStyle;
-    this.scheduleStyle = firstLoginReqDto.scheduleStyle;
-    this.destinationStyle1 = firstLoginReqDto.destinationStyle1;
-    this.destinationStyle2 = firstLoginReqDto.destinationStyle2;
-    this.destinationStyle3 = firstLoginReqDto.destinationStyle3;
-  }
-}
-
-export class FirstLoginResDto extends PickType(FirstLoginReqDto, [
-  'isAdConfirmed',
-  'nickname',
-  'birthDate',
-  'sex',
-  'mbti',
-  'preferredRegion',
-  'preferredCompanion',
-  'budgetStyle',
-  'planningStyle',
-  'scheduleStyle',
-  'destinationStyle1',
-  'destinationStyle2',
-  'destinationStyle3',
-]) {
-  @ApiProperty()
-  @IsString()
-  uuid: string;
-
-  @ApiProperty()
-  @IsString()
-  oAuthId: string;
-
-  @ApiProperty()
-  @IsEnum(OAuthPlatform)
-  oAuthPlatform: OAuthPlatform;
-
-  constructor(user: User) {
-    super(FirstLoginReqDto);
-    this.isAdConfirmed = user.isAdConfirmed;
-    this.uuid = user.uuid;
-    this.oAuthId = user.oAuthId;
-    this.oAuthPlatform = user.oAuthPlatform;
-    this.nickname = user.nickname;
-    this.birthDate = String(user.birthDate);
-    this.sex = user.sex;
-    this.mbti = user.mbti;
-    this.preferredRegion = user.preference.preferredRegion;
-    this.preferredCompanion = user.preference.preferredCompanion;
-    this.budgetStyle = user.preference.budgetStyle;
-    this.planningStyle = user.preference.planningStyle;
-    this.scheduleStyle = user.preference.scheduleStyle;
-    this.destinationStyle1 = user.preference.destinationStyle1;
-    this.destinationStyle2 = user.preference.destinationStyle2;
-    this.destinationStyle3 = user.preference.destinationStyle3;
-  }
+  restOrActivity: number;
 }

--- a/src/user/dtos/first-login.dto.ts
+++ b/src/user/dtos/first-login.dto.ts
@@ -20,7 +20,7 @@ import {
   preferredRegion,
 } from 'src/common/enums/preference.enum';
 
-export class FirstLoginReqDto {
+export class UpdateUserProfileReqDto {
   @ApiProperty({ description: '광고 동의 여부', nullable: true })
   @IsBoolean()
   @IsOptional()

--- a/src/user/dtos/profile-res.dto.ts
+++ b/src/user/dtos/profile-res.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { OAuthPlatform } from 'src/common/enums/oAuth-platform.enum';
 import { User } from '../entities/user.entity';
+import { Preference } from '../entities/preference.entity';
 
 export class ProfileResDto {
   @ApiProperty()
@@ -15,7 +16,7 @@ export class ProfileResDto {
   @ApiProperty()
   birthDate: Date;
 
-  @ApiProperty({ example: 'm' })
+  @ApiProperty({ example: 'M' })
   sex: string;
 
   @ApiProperty({ example: 'ISTJ' })
@@ -23,6 +24,9 @@ export class ProfileResDto {
 
   @ApiProperty()
   isAdConfirmed: boolean;
+
+  @ApiProperty({ type: Preference })
+  preference: Preference;
 
   constructor(user: User) {
     this.uuid = user.uuid;
@@ -32,5 +36,6 @@ export class ProfileResDto {
     this.sex = user.sex;
     this.mbti = user.mbti;
     this.isAdConfirmed = user.isAdConfirmed;
+    this.preference = user.preference;
   }
 }

--- a/src/user/dtos/update-user-profile-req.dto.ts
+++ b/src/user/dtos/update-user-profile-req.dto.ts
@@ -55,8 +55,8 @@ export class UpdateUserProfileReqDto {
   @ApiProperty({
     enum: preferredRegion,
     description:
-      '선호 지역들을 전달. 하나로 묶여있는 지역이라도 각각 따로 보내주세요',
-    example: ['충북', '충남', '대전', '경남', '울산'],
+      '선호 지역들을 전달. 하나로 묶여있는 지역이라도 각각 따로 보내주세요. 예시에 적힌 지역들만 전달 가능합니다. 여기에 해당하지 않으면 400 에러',
+    example: ['대전', '세종', '충북', '충남'],
   })
   @IsNotEmpty()
   @IsArray()

--- a/src/user/entities/preference.entity.ts
+++ b/src/user/entities/preference.entity.ts
@@ -14,28 +14,28 @@ export class Preference {
   id: number;
 
   @Column('varchar', { array: true })
-  preferredRegion: string[];
+  preferredRegions: string[];
 
   @Column('varchar', { array: true })
-  preferredCompanion: string[];
+  preferredCompanions: string[];
 
   @Column()
-  budgetStyle: number; //저렴한~비싼
+  cheapOrExpensive: number; //저렴한~비싼
 
   @Column()
-  planningStyle: number; //계획적~즉흥적
+  plannedOrImprovise: number; //계획적~즉흥적
 
   @Column()
-  scheduleStyle: number; //알차게~여유롭게
+  tightOrLoose: number; //알차게~여유롭게
 
   @Column()
-  destinationStyle1: number; //완전 관광지~완전 로컬
+  popularOrLocal: number; //완전 관광지~완전 로컬
 
   @Column()
-  destinationStyle2: number; //완전 자연~완전 도시
+  natureOrCity: number; //완전 자연~완전 도시
 
   @Column()
-  destinationStyle3: number; //휴양~액티비티
+  restOrActivity: number; //휴양~액티비티
 
   @OneToOne(() => User, (user) => user.preference)
   @JoinColumn()

--- a/src/user/entities/preference.entity.ts
+++ b/src/user/entities/preference.entity.ts
@@ -7,10 +7,12 @@ import {
   RelationId,
 } from 'typeorm';
 import { User } from './user.entity';
+import { Exclude } from 'class-transformer';
 
 @Entity()
 export class Preference {
   @PrimaryGeneratedColumn()
+  @Exclude()
   id: number;
 
   @Column('varchar', { array: true })

--- a/src/user/repositories/preference.repository.ts
+++ b/src/user/repositories/preference.repository.ts
@@ -1,4 +1,4 @@
-import { UpdateUserProfileReqDto } from './../dtos/first-login.dto';
+import { UpdateUserProfileReqDto } from '../dtos/update-user-profile-req.dto';
 import { Injectable } from '@nestjs/common';
 import { DataSource, Repository } from 'typeorm';
 import { Preference } from '../entities/preference.entity';

--- a/src/user/repositories/preference.repository.ts
+++ b/src/user/repositories/preference.repository.ts
@@ -1,4 +1,4 @@
-import { FirstLoginReqDto } from 'src/user/dtos/first-login.dto';
+import { UpdateUserProfileReqDto } from './../dtos/first-login.dto';
 import { Injectable } from '@nestjs/common';
 import { DataSource, Repository } from 'typeorm';
 import { Preference } from '../entities/preference.entity';
@@ -10,7 +10,10 @@ export class PreferenceRepository extends Repository<Preference> {
     super(Preference, dataSource.createEntityManager());
   }
 
-  async fillUserPreference(firstLoginReqDto: FirstLoginReqDto, user: User) {
-    return await this.save({ ...firstLoginReqDto, user });
+  async updateUserPreference(
+    updateUserProfileReqDto: UpdateUserProfileReqDto,
+    user: User,
+  ) {
+    return await this.save({ ...updateUserProfileReqDto, user });
   }
 }

--- a/src/user/repositories/preference.repository.ts
+++ b/src/user/repositories/preference.repository.ts
@@ -1,6 +1,6 @@
+import { FirstLoginReqDto } from 'src/user/dtos/first-login.dto';
 import { Injectable } from '@nestjs/common';
 import { DataSource, Repository } from 'typeorm';
-import { UserPreferenceDto } from 'src/user/dtos/first-login.dto';
 import { Preference } from '../entities/preference.entity';
 import { User } from '../entities/user.entity';
 
@@ -10,10 +10,7 @@ export class PreferenceRepository extends Repository<Preference> {
     super(Preference, dataSource.createEntityManager());
   }
 
-  async fillUserPreference(userPreferenceDto: UserPreferenceDto, id: number) {
-    const user = new User();
-    user.id = id;
-    const userPreference = this.create({ ...userPreferenceDto, user });
-    return await this.save(userPreference);
+  async fillUserPreference(firstLoginReqDto: FirstLoginReqDto, user: User) {
+    return await this.save({ ...firstLoginReqDto, user });
   }
 }

--- a/src/user/repositories/user.repository.ts
+++ b/src/user/repositories/user.repository.ts
@@ -1,6 +1,6 @@
+import { UpdateUserProfileReqDto } from './../dtos/first-login.dto';
 import { Injectable } from '@nestjs/common';
 import { DataSource, Repository } from 'typeorm';
-import { FirstLoginReqDto } from 'src/user/dtos/first-login.dto';
 import { OAuthPlatform } from 'src/common/enums/oAuth-platform.enum';
 import { User } from '../entities/user.entity';
 
@@ -41,16 +41,19 @@ export class UserRepository extends Repository<User> {
     return user;
   }
 
-  async fillUserInfo(firstLoginReqDto: FirstLoginReqDto, id: number) {
+  async updateUserInfo(
+    updateUserProfileReqDto: UpdateUserProfileReqDto,
+    id: number,
+  ) {
     const user = await this.getUserById(id);
 
-    user.isAdConfirmed = firstLoginReqDto.isAdConfirmed
-      ? firstLoginReqDto.isAdConfirmed
+    user.isAdConfirmed = updateUserProfileReqDto.isAdConfirmed
+      ? updateUserProfileReqDto.isAdConfirmed
       : false;
-    user.nickname = firstLoginReqDto.nickname;
-    user.birthDate = new Date(firstLoginReqDto.birthDate);
-    user.sex = firstLoginReqDto.sex;
-    user.mbti = firstLoginReqDto.mbti;
+    user.nickname = updateUserProfileReqDto.nickname;
+    user.birthDate = new Date(updateUserProfileReqDto.birthDate);
+    user.sex = updateUserProfileReqDto.sex;
+    user.mbti = updateUserProfileReqDto.mbti;
 
     return await this.save(user);
   }

--- a/src/user/repositories/user.repository.ts
+++ b/src/user/repositories/user.repository.ts
@@ -1,4 +1,4 @@
-import { UpdateUserProfileReqDto } from './../dtos/first-login.dto';
+import { UpdateUserProfileReqDto } from '../dtos/update-user-profile-req.dto';
 import { Injectable } from '@nestjs/common';
 import { DataSource, Repository } from 'typeorm';
 import { OAuthPlatform } from 'src/common/enums/oAuth-platform.enum';

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -9,7 +9,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { FirstLoginReqDto } from './dtos/first-login.dto';
+import { UpdateUserProfileReqDto } from './dtos/first-login.dto';
 import { UserService } from './user.service';
 import { NickNameDuplicateCheckResDto } from './dtos/nickname-dupliate-check-res.dto';
 import { ProfileResDto } from './dtos/profile-res.dto';
@@ -40,12 +40,12 @@ export class UserController {
   //최초 로그인시 유저 정보 받아오기.
   @UseAccessGuard()
   @Put('/me')
-  async fillUserInfoAndPreference(
-    @Body() firstLoginReqDto: FirstLoginReqDto,
+  async updateUserProfile(
+    @Body() updateUserProfileReqDto: UpdateUserProfileReqDto,
     @Req() req,
   ): Promise<ProfileResDto> {
-    return await this.userService.fillUserInfoAndPreference(
-      firstLoginReqDto,
+    return await this.userService.updateUserProfile(
+      updateUserProfileReqDto,
       req.user.id,
     );
   }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -9,7 +9,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { UpdateUserProfileReqDto } from './dtos/first-login.dto';
+import { UpdateUserProfileReqDto } from './dtos/update-user-profile-req.dto';
 import { UserService } from './user.service';
 import { NickNameDuplicateCheckResDto } from './dtos/nickname-dupliate-check-res.dto';
 import { ProfileResDto } from './dtos/profile-res.dto';

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -9,7 +9,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { FirstLoginReqDto, FirstLoginResDto } from './dtos/first-login.dto';
+import { FirstLoginReqDto } from './dtos/first-login.dto';
 import { UserService } from './user.service';
 import { NickNameDuplicateCheckResDto } from './dtos/nickname-dupliate-check-res.dto';
 import { ProfileResDto } from './dtos/profile-res.dto';
@@ -32,18 +32,18 @@ export class UserController {
 
   //사용자 프로필 정보 불러오기.
   @UseAccessGuard()
-  @Get('/me/profile')
+  @Get('/me')
   async getUserProfile(@Req() req): Promise<ProfileResDto> {
     return await this.userService.getUserProfile(req.user.id);
   }
 
   //최초 로그인시 유저 정보 받아오기.
   @UseAccessGuard()
-  @Put('/me/info')
+  @Put('/me')
   async fillUserInfoAndPreference(
     @Body() firstLoginReqDto: FirstLoginReqDto,
     @Req() req,
-  ): Promise<FirstLoginResDto> {
+  ): Promise<ProfileResDto> {
     return await this.userService.fillUserInfoAndPreference(
       firstLoginReqDto,
       req.user.id,

--- a/src/user/user.docs.ts
+++ b/src/user/user.docs.ts
@@ -1,17 +1,15 @@
 import { MethodNames } from 'src/common/types/method-names.type';
 import { UserController } from './user.controller';
 import {
-  ApiBearerAuth,
+  ApiBody,
   ApiCreatedResponse,
   ApiOkResponse,
   ApiOperation,
 } from '@nestjs/swagger';
 import { NickNameDuplicateCheckResDto } from './dtos/nickname-dupliate-check-res.dto';
-import { UseGuards } from '@nestjs/common';
-import { AccessGuard } from 'src/auth/guards/access.guard';
 import { ProfileResDto } from './dtos/profile-res.dto';
 import { ApiIeumExceptionRes } from 'src/common/decorators/api-ieum-exception-res.decorator';
-import { FirstLoginResDto } from './dtos/first-login.dto';
+import { FirstLoginReqDto } from './dtos/first-login.dto';
 
 type UserMethodNames = MethodNames<UserController>;
 
@@ -32,10 +30,14 @@ export const UserDocs: Record<UserMethodNames, MethodDecorator[]> = {
     ApiIeumExceptionRes(['USER_NOT_FOUND']),
   ],
   fillUserInfoAndPreference: [
-    ApiOperation({ summary: '유저 정보 및 선호도 입력' }),
+    ApiOperation({
+      summary: '유저 정보 및 선호도 입력',
+      description:
+        '선호 지역들을 전달할 때는, 하나로 묶여있는 지역이라도 각각 따로 보내주세요. ex) 대전/충청/세종으로 묶여있더라도 "대전", "충남", "충북", "세종"을 Array로 전달',
+    }),
     ApiCreatedResponse({
       description: '유저 정보 및 선호도 입력 성공',
-      type: FirstLoginResDto,
+      type: ProfileResDto,
     }),
     ApiIeumExceptionRes(['USER_NOT_FOUND']),
   ],

--- a/src/user/user.docs.ts
+++ b/src/user/user.docs.ts
@@ -30,8 +30,10 @@ export const UserDocs: Record<UserMethodNames, MethodDecorator[]> = {
   updateUserProfile: [
     ApiOperation({
       summary: '유저 프로필 변경',
-      description:
-        '선호 지역들을 전달할 때는, 하나로 묶여있는 지역이라도 각각 따로 보내주세요. ex) 대전/충청/세종으로 묶여있더라도 "대전", "충남", "충북", "세종"을 Array로 전달',
+      description: `
+      선호 지역들을 전달할 때는, 하나로 묶여있는 지역이라도 각각 따로 보내주세요.
+      ex) 대전/충청/세종으로 묶여있더라도 "대전", "충남", "충북", "세종"을 Array로 전달.
+      변경하지 않을 항목이 있다면, GET /users/me로 불러온 정보를 그대로 전달해주세요.`,
     }),
     ApiCreatedResponse({
       description: '유저 정보 및 선호도 입력 성공',

--- a/src/user/user.docs.ts
+++ b/src/user/user.docs.ts
@@ -1,7 +1,6 @@
 import { MethodNames } from 'src/common/types/method-names.type';
 import { UserController } from './user.controller';
 import {
-  ApiBody,
   ApiCreatedResponse,
   ApiOkResponse,
   ApiOperation,
@@ -9,7 +8,6 @@ import {
 import { NickNameDuplicateCheckResDto } from './dtos/nickname-dupliate-check-res.dto';
 import { ProfileResDto } from './dtos/profile-res.dto';
 import { ApiIeumExceptionRes } from 'src/common/decorators/api-ieum-exception-res.decorator';
-import { FirstLoginReqDto } from './dtos/first-login.dto';
 
 type UserMethodNames = MethodNames<UserController>;
 
@@ -29,9 +27,9 @@ export const UserDocs: Record<UserMethodNames, MethodDecorator[]> = {
     }),
     ApiIeumExceptionRes(['USER_NOT_FOUND']),
   ],
-  fillUserInfoAndPreference: [
+  updateUserProfile: [
     ApiOperation({
-      summary: '유저 정보 및 선호도 입력',
+      summary: '유저 프로필 변경',
       description:
         '선호 지역들을 전달할 때는, 하나로 묶여있는 지역이라도 각각 따로 보내주세요. ex) 대전/충청/세종으로 묶여있더라도 "대전", "충남", "충북", "세종"을 Array로 전달',
     }),

--- a/src/user/user.docs.ts
+++ b/src/user/user.docs.ts
@@ -31,15 +31,19 @@ export const UserDocs: Record<UserMethodNames, MethodDecorator[]> = {
     ApiOperation({
       summary: '유저 프로필 변경',
       description: `
-      선호 지역들을 전달할 때는, 하나로 묶여있는 지역이라도 각각 따로 보내주세요.
+      동반자 정보(preferredCompanions) / 선호 지역 정보(preferredRegions)는 보낼 수 있는 타입이 정해져있습니다!!!
+      Swagger 하단 Schema 정보에서 UpdateUserProfileReqDto를 확인해주세요. 각 필드에 대한 설명도 있어욧
+
+      선호 지역 정보는 Array로 전달해주세요. 프론트엔드 인터페이스상에서 하나로 묶여있더라도, 지역별로 따로 전달해주세요
       ex) 대전/충청/세종으로 묶여있더라도 "대전", "충남", "충북", "세종"을 Array로 전달.
+
       변경하지 않을 항목이 있다면, GET /users/me로 불러온 정보를 그대로 전달해주세요.`,
     }),
     ApiCreatedResponse({
       description: '유저 정보 및 선호도 입력 성공',
       type: ProfileResDto,
     }),
-    ApiIeumExceptionRes(['USER_NOT_FOUND']),
+    ApiIeumExceptionRes(['USER_NOT_FOUND', 'DUPLICATED_NICKNAME']),
   ],
   deleteUser: [
     ApiOperation({ summary: '회원탈퇴' }),

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,9 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import {
-  FirstLoginReqDto,
-  FirstLoginResDto,
-  UserPreferenceDto,
-} from './dtos/first-login.dto';
+import { FirstLoginReqDto } from './dtos/first-login.dto';
 import { UserRepository } from 'src/user/repositories/user.repository';
 import { PreferenceRepository } from 'src/user/repositories/preference.repository';
 import { NickNameDuplicateCheckResDto } from './dtos/nickname-dupliate-check-res.dto';
@@ -52,9 +48,8 @@ export class UserService {
   }
 
   //유저 정보
-  async getUserProfile(id: number): Promise<ProfileResDto> {
-    const user = await this.userRepository.getUserById(id);
-
+  async getUserProfile(userId: number): Promise<ProfileResDto> {
+    const user = await this.userRepository.getUserInfoAndPreferenceById(userId);
     if (!user) {
       throwIeumException('USER_NOT_FOUND');
     }
@@ -63,20 +58,17 @@ export class UserService {
 
   async fillUserInfoAndPreference(
     firstLoginReqDto: FirstLoginReqDto,
-    id: number,
-  ): Promise<FirstLoginResDto> {
-    const user = await this.userRepository.getUserById(id);
+    userId: number,
+  ): Promise<ProfileResDto> {
+    const user = await this.userRepository.getUserById(userId);
     if (!user) {
       throwIeumException('USER_NOT_FOUND');
     }
-    await this.userRepository.fillUserInfo(firstLoginReqDto, id);
-    await this.preferenceRepository.fillUserPreference(
-      new UserPreferenceDto(firstLoginReqDto),
-      id,
-    );
+    await this.userRepository.fillUserInfo(firstLoginReqDto, userId);
+    await this.preferenceRepository.fillUserPreference(firstLoginReqDto, user);
     const createdUser =
-      await this.userRepository.getUserInfoAndPreferenceById(id);
-    return new FirstLoginResDto(createdUser);
+      await this.userRepository.getUserInfoAndPreferenceById(userId);
+    return new ProfileResDto(createdUser);
   }
 
   //회원탈퇴

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { FirstLoginReqDto } from './dtos/first-login.dto';
+import { UpdateUserProfileReqDto } from './dtos/first-login.dto';
 import { UserRepository } from 'src/user/repositories/user.repository';
 import { PreferenceRepository } from 'src/user/repositories/preference.repository';
 import { NickNameDuplicateCheckResDto } from './dtos/nickname-dupliate-check-res.dto';
@@ -56,16 +56,19 @@ export class UserService {
     return new ProfileResDto(user);
   }
 
-  async fillUserInfoAndPreference(
-    firstLoginReqDto: FirstLoginReqDto,
+  async updateUserProfile(
+    updateUserProfileReqDto: UpdateUserProfileReqDto,
     userId: number,
   ): Promise<ProfileResDto> {
     const user = await this.userRepository.getUserById(userId);
     if (!user) {
       throwIeumException('USER_NOT_FOUND');
     }
-    await this.userRepository.fillUserInfo(firstLoginReqDto, userId);
-    await this.preferenceRepository.fillUserPreference(firstLoginReqDto, user);
+    await this.userRepository.updateUserInfo(updateUserProfileReqDto, userId);
+    await this.preferenceRepository.updateUserPreference(
+      updateUserProfileReqDto,
+      user,
+    );
     const createdUser =
       await this.userRepository.getUserInfoAndPreferenceById(userId);
     return new ProfileResDto(createdUser);

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { UpdateUserProfileReqDto } from './dtos/first-login.dto';
+import { UpdateUserProfileReqDto } from './dtos/update-user-profile-req.dto';
 import { UserRepository } from 'src/user/repositories/user.repository';
 import { PreferenceRepository } from 'src/user/repositories/preference.repository';
 import { NickNameDuplicateCheckResDto } from './dtos/nickname-dupliate-check-res.dto';

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -64,6 +64,12 @@ export class UserService {
     if (!user) {
       throwIeumException('USER_NOT_FOUND');
     }
+    const nicknameCheck = await this.userRepository.getUserByNickname(
+      updateUserProfileReqDto.nickname,
+    );
+    if (nicknameCheck && nicknameCheck.id !== userId) {
+      throwIeumException('DUPLICATED_NICKNAME');
+    }
     await this.userRepository.updateUserInfo(updateUserProfileReqDto, userId);
     await this.preferenceRepository.updateUserPreference(
       updateUserProfileReqDto,


### PR DESCRIPTION
## Description 
- preference의 칼럼이 각각 어떤 데이터인지 알기 어려워서, 좀 더 직관적인 네이밍으로 수정하였습니다.
- region, companion, MBTI는 enum으로 체크하도록 바꿨습니다.
- 엔드포인트명을 좀 더 RESTful하게 바꿨습니다. 유저 프로필 조회는 GET /users/me, 정보 변경은 PUT /users/me.
- 둘 다 ProfileResDto 형태를 리턴하도록 수정했고, 이에 따라 불필요하다고 생각하는 DTO는 제거했습니다.
- 메서드명도 좀 더 범용적인 사용을 위해, get과 update로 통일했습니다.

## To Discuss


## Test


## ETC
엔터티 변경사항 반영을 위해서, preference 테이블을 삭제 후 재생성할 예정입니다. 
테스트할 때는 정보를 다시 채워서 부탁드려요.

## Related Issues
관련된 이슈를 태그와 함께 작성해주세요(Fixes, Resolves, Ref, Related to...)
