### PR TITLE
feat : 폴더에 장소를 저장할 때 장소 상세 정보를 자동으로 생성하기

### DIFF
--- a/src/auth/auth.docs.ts
+++ b/src/auth/auth.docs.ts
@@ -26,6 +26,8 @@ export const AuthDocs: Record<AuthMethodName, MethodDecorator[]> = {
   socialLogin: [
     ApiOperation({
       summary: '소셜 로그인',
+      description:
+        'OAuthPlatform: Kakao, Naver, Apple. FCMToken은 푸시 알림을 받는 기기의 토큰으로, 필수는 아닙니다',
     }),
     ApiCreatedResponse({
       description: '소셜 로그인 성공',

--- a/src/folder/folder.module.ts
+++ b/src/folder/folder.module.ts
@@ -8,6 +8,7 @@ import { Folder } from './entities/folder.entity';
 import { FolderPlace } from './entities/folder-place.entity';
 import { FolderTag } from './entities/folder-tag.entity';
 import { UserModule } from 'src/user/user.module';
+import { PlaceModule } from 'src/place/place.module';
 
 @Module({
   controllers: [FolderController],
@@ -15,6 +16,7 @@ import { UserModule } from 'src/user/user.module';
   imports: [
     TypeOrmModule.forFeature([Folder, FolderPlace, FolderTag]),
     UserModule,
+    PlaceModule,
   ],
   exports: [FolderService],
 })

--- a/src/folder/folder.service.ts
+++ b/src/folder/folder.service.ts
@@ -17,12 +17,14 @@ import { PlacesListResDto } from 'src/place/dtos/paginated-places-list-res.dto';
 import { throwIeumException } from 'src/common/utils/exception.util';
 import { CATEGORIES_MAPPING_KAKAO } from 'src/common/utils/category-mapper.util';
 import { Folder } from './entities/folder.entity';
+import { PlaceService } from 'src/place/place.service';
 
 @Injectable()
 export class FolderService {
   constructor(
     private readonly folderRepository: FolderRepository,
     private readonly folderPlaceRepository: FolderPlaceRepository,
+    private readonly placeService: PlaceService,
   ) {}
 
   // ------폴더 관련 메서드------

--- a/src/place/place.controller.ts
+++ b/src/place/place.controller.ts
@@ -64,8 +64,11 @@ export class PlaceController {
 
   @UseNicknameCheckingAccessGuard()
   @Get('/:placeId')
-  async getPlaceDetailById(@Req() req, @Param('placeId') placeId: string) {
-    return await this.placeService.getPlaceDetailById(
+  async getPlaceDetailWithImagesAndCollectionsById(
+    @Req() req,
+    @Param('placeId') placeId: string,
+  ) {
+    return await this.placeService.getPlaceDetailWithImagesAndCollectionsById(
       req.user.id,
       parseInt(placeId),
     );

--- a/src/place/place.docs.ts
+++ b/src/place/place.docs.ts
@@ -20,7 +20,7 @@ export const PlaceDocs: Record<PlaceMethodName, MethodDecorator[]> = {
     ApiOperation({ summary: '장소명으로 DB 내의 장소 검색' }),
     ApiQuery({ name: 'placeName', type: 'string' }),
   ],
-  getPlaceDetailById: [
+  getPlaceDetailWithImagesAndCollectionsById: [
     ApiOperation({ summary: '특정 장소의 상세 정보 조회' }),
     ApiOkResponse({
       description: '상세 정보 조회 성공',

--- a/src/place/place.service.ts
+++ b/src/place/place.service.ts
@@ -167,16 +167,19 @@ export class PlaceService {
   }
 
   // ---------내부 DB 검색---------
-  async getPlaceDetailById(
+  async getPlaceDetailById(placeId: number): Promise<Place> {
+    const placeDetail = await this.placeRepository.getPlaceDetailById(placeId);
+    if (!placeDetail) {
+      throwIeumException('PLACE_NOT_FOUND');
+    }
+    return placeDetail;
+  }
+
+  async getPlaceDetailWithImagesAndCollectionsById(
     userId: number,
     placeId: number,
   ): Promise<PlaceDetailResDto> {
-    const place = await this.placeRepository.getPlaceDetailById(placeId);
-    if (!place) {
-      throwIeumException('PLACE_NOT_FOUND');
-    }
-
-    const placeDetail = await this.placeRepository.getPlaceDetailById(placeId);
+    const placeDetail = await this.getPlaceDetailById(placeId);
     const placeImages =
       await this.placeImageRepository.getPlaceImagesByPlaceId(placeId);
     const linkedCollections = await this.collectionService.getLinkedCollections(


### PR DESCRIPTION
## Description 
- 기존의 장소 상세 정보(placeDetail, placeImages, LinkedCollectiosn)를 가져오는 메서드에서, PlaceDetail을 가져오는 부분만 따로 분리하고, 네이밍을 수정했습니다
- 폴더에 장소를 추가할 때, placeDetail을 포함한 place 엔터티를 get하여 placeId 자체의 유효성 체크와, placeDetail의 존재 유무를 동시에 체크합니다
- placeDetail이 존재하지 않는다면, placeDetail + placeImages를 생성하는 메서드를 호출합니다.
- 폴더에 장소를 저장하는 로직이 핵심이고, 장소 상세 정보 생성은 부가적인 것이므로, 장소 상세 정보 생성에서 에러가 발생한다고 트랜잭션 전체가 롤백되지 않도록 try-catch로 감싼 뒤, 내장 로거를 통해 로그만 찍도록 구성했습니다. 추후 메세징 관련 모듈을 따로 분리하는 과정에서 슬랙을 통해 알림을 주도록 바꿀 예정입니다.
- 여러 장소를 한번에 추가하는 경우에 순서가 중요하지는 않다고 생각하여 Promise.all과 map을 이용한 병렬 처리를 하게 만들었습니다.

## To Discuss


## Test
x

## ETC


## Related Issues
x
