### PR TITLE
refactor & feat : 아키텍처 개선 및 특정 장소 저장 여부를 담은 폴더 리스트 

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -22,6 +22,8 @@ import { PrometheusModule } from '@willsoto/nestjs-prometheus';
 import { ExporterMiddleware } from './common/middleware/exporter.middleware';
 import { WinstonLoggerMiddleware } from './common/middleware/winston.logger.middleware';
 import { CollectionComplexModule } from './collection-complex/collection-complex.module';
+import { PlaceComplexModule } from './place-complex/place-complex.module';
+import { FolderComplexModule } from './folder-complex/folder-complex.module';
 
 @Module({
   imports: [
@@ -64,6 +66,8 @@ import { CollectionComplexModule } from './collection-complex/collection-complex
     CollectionModule,
     CrawlingModule,
     CollectionComplexModule,
+    PlaceComplexModule,
+    FolderComplexModule,
   ],
   controllers: [AppController],
   providers: [AppService, S3Service, ExporterService],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -21,6 +21,7 @@ import { ExporterService } from './exporter/exporter.service';
 import { PrometheusModule } from '@willsoto/nestjs-prometheus';
 import { ExporterMiddleware } from './common/middleware/exporter.middleware';
 import { WinstonLoggerMiddleware } from './common/middleware/winston.logger.middleware';
+import { CollectionComplexModule } from './collection-complex/collection-complex.module';
 
 @Module({
   imports: [
@@ -62,6 +63,7 @@ import { WinstonLoggerMiddleware } from './common/middleware/winston.logger.midd
     FolderModule,
     CollectionModule,
     CrawlingModule,
+    CollectionComplexModule,
   ],
   controllers: [AppController],
   providers: [AppService, S3Service, ExporterService],

--- a/src/collection-complex/collection-complex.controller.ts
+++ b/src/collection-complex/collection-complex.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('collection-complex')
+export class CollectionComplexController {}

--- a/src/collection-complex/collection-complex.module.ts
+++ b/src/collection-complex/collection-complex.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CollectionComplexController } from './collection-complex.controller';
+import { CollectionComplexService } from './collection-complex.service';
+
+@Module({
+  controllers: [CollectionComplexController],
+  providers: [CollectionComplexService]
+})
+export class CollectionComplexModule {}

--- a/src/collection-complex/collection-complex.module.ts
+++ b/src/collection-complex/collection-complex.module.ts
@@ -1,9 +1,14 @@
 import { Module } from '@nestjs/common';
 import { CollectionComplexController } from './collection-complex.controller';
 import { CollectionComplexService } from './collection-complex.service';
+import { CollectionModule } from 'src/collection/collection.module';
+import { UserModule } from 'src/user/user.module';
+import { PlaceModule } from 'src/place/place.module';
+import { FolderModule } from 'src/folder/folder.module';
 
 @Module({
+  imports: [CollectionModule, UserModule, PlaceModule, FolderModule],
   controllers: [CollectionComplexController],
-  providers: [CollectionComplexService]
+  providers: [CollectionComplexService],
 })
 export class CollectionComplexModule {}

--- a/src/collection-complex/collection-complex.service.ts
+++ b/src/collection-complex/collection-complex.service.ts
@@ -1,4 +1,15 @@
 import { Injectable } from '@nestjs/common';
+import { CollectionService } from 'src/collection/collection.service';
+import { FolderService } from 'src/folder/folder.service';
+import { PlaceService } from 'src/place/services/place.service';
 
 @Injectable()
-export class CollectionComplexService {}
+export class CollectionComplexService {
+  constructor(
+    private readonly collectionService: CollectionService,
+    private readonly folderService: FolderService,
+    private readonly placeService: PlaceService,
+  ) {}
+
+  async getCollectionPlaceDetail(collectionPlaceId: number) {}
+}

--- a/src/collection-complex/collection-complex.service.ts
+++ b/src/collection-complex/collection-complex.service.ts
@@ -10,6 +10,4 @@ export class CollectionComplexService {
     private readonly folderService: FolderService,
     private readonly placeService: PlaceService,
   ) {}
-
-  async getCollectionPlaceDetail(collectionPlaceId: number) {}
 }

--- a/src/collection-complex/collection-complex.service.ts
+++ b/src/collection-complex/collection-complex.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class CollectionComplexService {}

--- a/src/collection/collection.docs.ts
+++ b/src/collection/collection.docs.ts
@@ -1,16 +1,8 @@
 import { MethodNames } from 'src/common/types/method-names.type';
 import { CollectionController } from './collection.controller';
-import { UseGuards } from '@nestjs/common';
-import { AccessGuard } from 'src/auth/guards/access.guard';
-import {
-  ApiBearerAuth,
-  ApiOkResponse,
-  ApiOperation,
-  ApiQuery,
-} from '@nestjs/swagger';
+import { ApiOkResponse, ApiOperation, ApiQuery } from '@nestjs/swagger';
 import { CollectionsListResDto } from './dtos/paginated-collections-list-res.dto';
 import { CollectionPlacesListResDto } from './dtos/collection-places-list-res.dto';
-import { UseNicknameCheckingAccessGuard } from 'src/auth/guards/nickname-check-access.guard';
 import { ApiIeumExceptionRes } from 'src/common/decorators/api-ieum-exception-res.decorator';
 
 type CollectionMethodName = MethodNames<CollectionController>;

--- a/src/collection/collection.service.ts
+++ b/src/collection/collection.service.ts
@@ -44,6 +44,21 @@ export class CollectionService {
     );
   }
 
+  async getCollectionPlaceDetail(
+    userId: number,
+    collectionId: number,
+    collectionPlaceId: number,
+  ) {
+    //특정 collectionPlaceId에 대해서 유저의 폴더 목록 가져와서, 각 폴더에 대해 collectionPlaceId의 포함 여부 확인
+    //collectionPlaceId가 포
+    // const collectionPlace =
+    //   await this.collectionPlaceRepository.getCollectionPlaceDetail(
+    //     collectionPlaceId,
+    //   );
+    // await this.collectionRepository.updateIsViewed(userId, collectionId);
+    // return collectionPlace;
+  }
+
   @Transactional()
   async getCollectionPlaces(userId: number, collectionId: number) {
     const collection = await this.collectionRepository.findOne({

--- a/src/common/interfaces/raw-folder-info.interface.ts
+++ b/src/common/interfaces/raw-folder-info.interface.ts
@@ -11,3 +11,7 @@ export interface FolderInfo {
 export interface FolderInfoWithThumbnail extends FolderInfo {
   folderThumbnailUrl: string;
 }
+
+export interface FolderInfoWithPlaceExistence extends FolderInfo {
+  placeExistence: boolean;
+}

--- a/src/folder-complex/folder-complex.controller.ts
+++ b/src/folder-complex/folder-complex.controller.ts
@@ -1,4 +1,117 @@
-import { Controller } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Query,
+  Req,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { UseNicknameCheckingAccessGuard } from 'src/auth/guards/nickname-check-access.guard';
+import { DeletePlacesReqDto } from 'src/folder/dtos/delete-places-req.dto';
+import { FolderComplexService } from './folder-complex.service';
+import { MarkersListResDto } from 'src/place/dtos/markers-list-res.dto';
+import {
+  MarkersReqDto,
+  PlacesListReqDto,
+} from 'src/place/dtos/places-list-req.dto';
+import { CreateFolderPlacesReqDto } from 'src/folder/dtos/create-folder-place-req.dto';
+import { PlacesListResDto } from 'src/place/dtos/paginated-places-list-res.dto';
+import { ApplyDocs } from 'src/common/decorators/apply-docs.decorator';
+import { FolderComplexDocs } from './folder-complex.docs';
 
-@Controller('folder-complex')
-export class FolderComplexController {}
+@UseNicknameCheckingAccessGuard()
+@ApplyDocs(FolderComplexDocs)
+@ApiTags('폴더 API')
+@Controller('folders')
+export class FolderComplexController {
+  constructor(private readonly folderComplexService: FolderComplexService) {}
+
+  @Delete('/:folderId/folder-places')
+  async deleteFolderPlaces(
+    @Param('folderId') folderId: number,
+    @Body() deletePlacesReqDto: DeletePlacesReqDto,
+    @Req() req,
+  ) {
+    return await this.folderComplexService.deleteFolderPlaces(
+      req.user.id,
+      folderId,
+      deletePlacesReqDto.placeIds,
+    );
+  }
+
+  @Get('/default/markers')
+  async getAllMarkers(
+    @Query() markersReqDto: MarkersReqDto,
+    @Req() req,
+  ): Promise<MarkersListResDto> {
+    return await this.folderComplexService.getMarkers(
+      req.user.id,
+      markersReqDto,
+    );
+  }
+
+  @Get('/:folderId/markers')
+  async getMarkersByFolder(
+    @Param('folderId') folderId: number,
+    @Query() markersReqDto: MarkersReqDto,
+    @Req() req,
+  ): Promise<MarkersListResDto> {
+    console.log('controller before method', req.user);
+    return await this.folderComplexService.getMarkers(
+      req.user.id,
+      markersReqDto,
+      folderId,
+    );
+  }
+
+  @Get('/default/places-list')
+  async getAllPlacesList(
+    @Req() req,
+    @Query() placesListReqDto: PlacesListReqDto,
+  ): Promise<PlacesListResDto> {
+    return this.folderComplexService.getPlacesList(
+      req.user.id,
+      placesListReqDto,
+    );
+  }
+
+  @Get('/:folderId/places-list')
+  async getPlaceListByFolder(
+    @Req() req,
+    @Param('folderId') folderId: number,
+    @Query() placesListReqDto: PlacesListReqDto,
+  ): Promise<PlacesListResDto> {
+    return this.folderComplexService.getPlacesList(
+      req.user.id,
+      placesListReqDto,
+      folderId,
+    );
+  }
+
+  @Post('/default/folder-places')
+  async createFolderPlacesIntoDefaultFolder(
+    @Body() createFolderPlacesReqDto: CreateFolderPlacesReqDto,
+    @Req() req,
+  ) {
+    return await this.folderComplexService.createFolderPlacesIntoDefaultFolder(
+      req.user.id,
+      createFolderPlacesReqDto,
+    );
+  }
+
+  @Post('/:folderId/folder-places')
+  async createFolderPlacesIntoFolder(
+    @Param('folderId') folderId: number,
+    @Body() createFolderPlacesReqDto: CreateFolderPlacesReqDto,
+    @Req() req,
+  ) {
+    return await this.folderComplexService.createFolderPlacesIntoSpecificFolder(
+      req.user.id,
+      createFolderPlacesReqDto,
+      folderId,
+    );
+  }
+}

--- a/src/folder-complex/folder-complex.controller.ts
+++ b/src/folder-complex/folder-complex.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('folder-complex')
+export class FolderComplexController {}

--- a/src/folder-complex/folder-complex.docs.ts
+++ b/src/folder-complex/folder-complex.docs.ts
@@ -1,0 +1,97 @@
+import { MethodNames } from 'src/common/types/method-names.type';
+import {
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiOperation,
+} from '@nestjs/swagger';
+import { ApiIeumExceptionRes } from 'src/common/decorators/api-ieum-exception-res.decorator';
+import { MarkersListResDto } from 'src/place/dtos/markers-list-res.dto';
+import { PlacesListResDto } from 'src/place/dtos/paginated-places-list-res.dto';
+import { FolderComplexController } from './folder-complex.controller';
+import { CreateFolderPlaceResDto } from 'src/folder/dtos/create-folder-place-res.dto';
+
+type FolderComplexMethodName = MethodNames<FolderComplexController>;
+
+export const FolderComplexDocs: Record<
+  FolderComplexMethodName,
+  MethodDecorator[]
+> = {
+  deleteFolderPlaces: [
+    ApiOperation({
+      summary: '특정 폴더에서 장소 삭제하기',
+      description:
+        '특정 폴더에서 장소를 삭제합니다. 대상 폴더가 디폴트 폴더라면, 모든 폴더에서 해당 장소들을 삭제합니다',
+    }),
+    ApiOkResponse({
+      description: '폴더에서 장소 삭제 성공.',
+    }),
+    ApiIeumExceptionRes(['FOLDER_NOT_FOUND', 'FORBIDDEN_FOLDER']),
+  ],
+  getAllMarkers: [
+    ApiOperation({
+      summary: '저장한 모든 장소의 마커 리스트 가져오기',
+      description: `저장한 모든 장소, 즉 Default Folder에 담겨있는 마커 리스트를 가져옵니다.
+      이음 앱 내에서 사용되는 카테고리인 IeumCategory(FOOD, CAFE, ALCOHOL, MUSEUM, SHOPPING, STAY)에 따라 마커를 필터링하여 가져올 수 있습니다.
+      또한 지역별(서울, 경기, 충북, 충남..)로 마커를 필터링하여 가져올 수 있습니다.`,
+    }),
+    ApiOkResponse({ description: '성공', type: MarkersListResDto }),
+  ],
+  getMarkersByFolder: [
+    ApiOperation({
+      summary: '특정 폴더의 장소 마커 리스트 가져오기',
+      description: `특정 폴더 내의 장소 마커 리스트를 가져옵니다.
+      이음 앱 내에서 사용되는 카테고리인 IeumCategory(FOOD, CAFE, ALCOHOL, MUSEUM, SHOPPING, STAY)에 따라 마커를 필터링하여 가져올 수 있습니다.
+      또한 지역별(서울, 경기, 충북, 충남..)로 마커를 필터링하여 가져올 수 있습니다.`,
+    }),
+    ApiOkResponse({ description: '성공', type: MarkersListResDto }),
+    ApiIeumExceptionRes(['FOLDER_NOT_FOUND', 'FORBIDDEN_FOLDER']),
+  ],
+  getAllPlacesList: [
+    ApiOperation({
+      summary: '저장한 모든 장소 리스트 가져오기',
+      description: `
+      저장한 모든 장소, 즉 Default Folder에 담겨있는 장소 리스트를 가져옵니다.
+      이음 앱 내에서 사용되는 카테고리인 IeumCategory(FOOD, CAFE, ALCOHOL, MUSEUM, SHOPPING, STAY)에 따라 장소를 필터링하여 가져올 수 있습니다.
+      또한 지역별(서울, 경기, 충북, 충남..)로 장소를 필터링하여 가져올 수 있습니다.
+      `,
+    }),
+    ApiOkResponse({ description: '성공', type: PlacesListResDto }),
+  ],
+  getPlaceListByFolder: [
+    ApiOperation({
+      summary: '특정 폴더의 장소 리스트 가져오기',
+      description: `
+      저장한 모든 장소, 즉 Default Folder에 담겨있는 장소 리스트를 가져옵니다.
+      이음 앱 내에서 사용되는 카테고리인 IeumCategory(FOOD, CAFE, ALCOHOL, MUSEUM, SHOPPING, STAY)에 따라 장소를 필터링하여 가져올 수 있습니다.
+      또한 지역별(서울, 경기, 충북, 충남..)로 장소를 필터링하여 가져올 수 있습니다.
+      `,
+    }),
+    ApiOkResponse({ description: '성공', type: PlacesListResDto }),
+    ApiIeumExceptionRes(['FOLDER_NOT_FOUND', 'FORBIDDEN_FOLDER']),
+  ],
+  createFolderPlacesIntoDefaultFolder: [
+    ApiOperation({
+      summary: '디폴트 폴더에 장소 추가하기',
+      description: `
+      폴더를 지정하지 않고, 디폴트 폴더(저장한 장소)에 장소를 추가합니다.
+      해당 장소가 최초로 폴더에 저장된 경우, 장소 상세 정보를 추가적으로 생성합니다.`,
+    }),
+    ApiCreatedResponse({
+      description: '디폴트 폴더에 장소 추가 성공',
+      type: CreateFolderPlaceResDto,
+    }),
+  ],
+  createFolderPlacesIntoFolder: [
+    ApiOperation({
+      summary: '특정 폴더에 장소 추가하기',
+      description: `
+      특정 폴더에 장소를 추가합니다.
+      해당 장소가 최초로 폴더에 저장된 경우, 장소 상세 정보를 추가적으로 생성합니다.`,
+    }),
+    ApiCreatedResponse({
+      description: '특정 폴더에 장소 추가 성공',
+      type: CreateFolderPlaceResDto,
+    }),
+    ApiIeumExceptionRes(['FOLDER_NOT_FOUND', 'FORBIDDEN_FOLDER']),
+  ],
+};

--- a/src/folder-complex/folder-complex.module.ts
+++ b/src/folder-complex/folder-complex.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { FolderComplexController } from './folder-complex.controller';
+import { FolderComplexService } from './folder-complex.service';
+
+@Module({
+  controllers: [FolderComplexController],
+  providers: [FolderComplexService]
+})
+export class FolderComplexModule {}

--- a/src/folder-complex/folder-complex.module.ts
+++ b/src/folder-complex/folder-complex.module.ts
@@ -1,9 +1,13 @@
 import { Module } from '@nestjs/common';
 import { FolderComplexController } from './folder-complex.controller';
 import { FolderComplexService } from './folder-complex.service';
+import { FolderModule } from 'src/folder/folder.module';
+import { PlaceModule } from 'src/place/place.module';
+import { UserModule } from 'src/user/user.module';
 
 @Module({
+  imports: [FolderModule, PlaceModule, UserModule],
   controllers: [FolderComplexController],
-  providers: [FolderComplexService]
+  providers: [FolderComplexService],
 })
 export class FolderComplexModule {}

--- a/src/folder-complex/folder-complex.service.ts
+++ b/src/folder-complex/folder-complex.service.ts
@@ -1,4 +1,200 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
+import { FolderType } from 'src/common/enums/folder-type.enum';
+import { throwIeumException } from 'src/common/utils/exception.util';
+import { CreateFolderPlacesReqDto } from 'src/folder/dtos/create-folder-place-req.dto';
+import { CreateFolderPlaceResDto } from 'src/folder/dtos/create-folder-place-res.dto';
+import { FolderService } from 'src/folder/folder.service';
+import { MarkersListResDto } from 'src/place/dtos/markers-list-res.dto';
+import { PlacesListResDto } from 'src/place/dtos/paginated-places-list-res.dto';
+import {
+  MarkersReqDto,
+  PlacesListReqDto,
+} from 'src/place/dtos/places-list-req.dto';
+import { PlaceService } from 'src/place/services/place.service';
+import { Transactional } from 'typeorm-transactional';
 
 @Injectable()
-export class FolderComplexService {}
+export class FolderComplexService {
+  private readonly logger = new Logger(FolderComplexService.name);
+  constructor(
+    private readonly folderService: FolderService,
+    private readonly placeService: PlaceService,
+  ) {}
+
+  async getMarkers(
+    userId: number,
+    markersReqDto: MarkersReqDto,
+    folderId?: number,
+  ): Promise<MarkersListResDto> {
+    if (folderId) {
+      await this.folderService.getRawFolderByIdWithCheckingStatus(
+        userId,
+        folderId,
+      );
+    }
+    const { addressList, categoryList } = markersReqDto;
+    const kakaoCategoriesForFiltering = await Promise.all(
+      categoryList.map(async (category) => {
+        return await this.placeService.getKakaoCategoriesByIeumCategory(
+          category,
+        );
+      }),
+    );
+    const rawMarkersList = await this.folderService.getRawMarkers(
+      userId,
+      addressList,
+      kakaoCategoriesForFiltering.flat(),
+      folderId,
+    );
+
+    await Promise.all(
+      rawMarkersList.map(async (marker) => {
+        marker.ieumCategory =
+          await this.placeService.getIeumCategoryByKakaoCategory(
+            marker.primary_category,
+          );
+        return marker; // 이 반환값은 실제로 사용되지 않지만, 명시적으로 표현
+      }),
+    );
+
+    return new MarkersListResDto(rawMarkersList);
+  }
+
+  async getPlacesList(
+    userId: number,
+    placesListReqDto: PlacesListReqDto,
+    folderId?: number,
+  ): Promise<PlacesListResDto> {
+    if (folderId) {
+      await this.folderService.getRawFolderByIdWithCheckingStatus(
+        userId,
+        folderId,
+      );
+    }
+    const { take, cursorId, addressList, categoryList } = placesListReqDto;
+    const kakaoCategoriesForFiltering = await Promise.all(
+      categoryList.map(async (category) => {
+        return await this.placeService.getKakaoCategoriesByIeumCategory(
+          category,
+        );
+      }),
+    );
+
+    const rawPlacesInfoList = await this.folderService.getRawPlacesList(
+      userId,
+      take,
+      addressList,
+      kakaoCategoriesForFiltering.flat(),
+      cursorId,
+      folderId,
+    );
+
+    await Promise.all(
+      rawPlacesInfoList.map(async (placeInfo) => {
+        placeInfo.ieumCategory =
+          await this.placeService.getIeumCategoryByKakaoCategory(
+            placeInfo.primary_category,
+          );
+        return placeInfo; // 이 반환값은 실제로 사용되지 않지만, 명시적으로 표현
+      }),
+    );
+    return new PlacesListResDto(rawPlacesInfoList, placesListReqDto.take);
+  }
+
+  async createFolderPlacesIntoFolder(
+    //기본 Folder-place 저장 로직
+    userId: number,
+    createFolderPlacesReqDto: CreateFolderPlacesReqDto,
+    folderId: number,
+  ) {
+    const placeIds = createFolderPlacesReqDto.placeIds;
+    await this.folderService.getRawFolderByIdWithCheckingStatus(
+      userId,
+      folderId,
+    );
+    //placeId에 대한 유효성 체크가 가능한가? -> placeService 주입.
+    //
+    await Promise.all(
+      placeIds.map(async (placeId) => {
+        const place = await this.placeService.getPlaceDetailById(placeId); // 내부에서 유효성 체크 일어난다.
+        if (!place.placeDetail) {
+          // 만약 이 내부에서 fail이 일어나면 어떻게 처리할 것인가?
+          try {
+            await this.placeService.createPlaceDetailByGooglePlacesApi(placeId);
+          } catch (error) {
+            this.logger.error(
+              `Failed to create PlaceDetail By placeId : ${placeId}`,
+            );
+          }
+        }
+        await this.folderService.createFolderPlace(folderId, placeId);
+      }),
+    );
+  }
+
+  @Transactional()
+  async createFolderPlacesIntoDefaultFolder(
+    // Default 폴더에만 저장할 때 호출되는 메서드
+    userId: number,
+    createFolderPlacesReqDto: CreateFolderPlacesReqDto,
+  ): Promise<CreateFolderPlaceResDto> {
+    const defaultFolder = await this.folderService.getDefaultFolder(userId);
+    await this.createFolderPlacesIntoFolder(
+      userId,
+      createFolderPlacesReqDto,
+      defaultFolder.id,
+    );
+
+    return new CreateFolderPlaceResDto(createFolderPlacesReqDto.placeIds);
+  }
+
+  @Transactional()
+  async createFolderPlacesIntoSpecificFolder(
+    // 특정 폴더에 저장할 때 호출되는 메서드. default 폴더에도 저장하고, 특정 폴더에도 저장
+    userId: number,
+    createFolderPlacesReqDto: CreateFolderPlacesReqDto,
+    folderId: number,
+  ): Promise<CreateFolderPlaceResDto> {
+    await this.createFolderPlacesIntoDefaultFolder(
+      userId,
+      createFolderPlacesReqDto,
+    );
+    await this.createFolderPlacesIntoFolder(
+      userId,
+      createFolderPlacesReqDto,
+      folderId,
+    );
+
+    return new CreateFolderPlaceResDto(
+      createFolderPlacesReqDto.placeIds,
+      folderId,
+    );
+  }
+
+  @Transactional()
+  async deleteFolderPlaces(
+    userId: number,
+    folderId: number,
+    placeIds: number[],
+  ) {
+    const targetFolder =
+      await this.folderService.getRawFolderByIdWithCheckingStatus(
+        userId,
+        folderId,
+      );
+
+    if (targetFolder.type == FolderType.Default) {
+      //디폴트 폴더라면, 나머지 폴더에서도 전부 삭제
+      const foldersList = await this.folderService.getRawFoldersList(userId);
+      foldersList.forEach(async (folder) => {
+        await this.folderService.deleteFolderPlaces(folder.id, placeIds);
+      });
+    }
+
+    return await this.folderService.deleteFolderPlaces(
+      //해당 폴더에서 삭제
+      folderId,
+      placeIds,
+    );
+  }
+}

--- a/src/folder-complex/folder-complex.service.ts
+++ b/src/folder-complex/folder-complex.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class FolderComplexService {}

--- a/src/folder/dtos/folders-list.res.dto.ts
+++ b/src/folder/dtos/folders-list.res.dto.ts
@@ -3,6 +3,7 @@ import { IsArray } from 'class-validator';
 import { FolderType } from 'src/common/enums/folder-type.enum';
 import {
   FolderInfo,
+  FolderInfoWithPlaceExistence,
   FolderInfoWithThumbnail,
 } from 'src/common/interfaces/raw-folder-info.interface';
 import {
@@ -39,6 +40,16 @@ export class FolderWithThumbnailResDto extends FolderResDto {
   constructor(folderInfoWithThumbnail: FolderInfoWithThumbnail) {
     super(folderInfoWithThumbnail);
     this.thumbnailUrl = folderInfoWithThumbnail.folderThumbnailUrl;
+  }
+}
+
+export class FolderWithPlaceExistenceResDto extends FolderResDto {
+  @ApiProperty()
+  placeExistence: boolean;
+
+  constructor(folderInfo: FolderInfoWithPlaceExistence) {
+    super(folderInfo);
+    this.placeExistence = folderInfo.placeExistence;
   }
 }
 export class FoldersListResDto {
@@ -79,6 +90,24 @@ export class FoldersWithThumbnailListResDto {
       foldersInfoWithThumbnailList,
       (folderInfoWithThumbnail) =>
         new FolderWithThumbnailResDto(folderInfoWithThumbnail),
+    );
+    this.meta = meta;
+    this.items = items;
+  }
+}
+
+export class FoldersWithPlaceExistenceListResDto {
+  @ApiProperty()
+  meta: NormalListMeta<FolderInfo>;
+
+  @ApiProperty({ type: [FolderWithPlaceExistenceResDto] })
+  @IsArray()
+  items: FolderWithPlaceExistenceResDto[];
+
+  constructor(foldersInfoList: FolderInfoWithPlaceExistence[]) {
+    const { meta, items } = createNormalList(
+      foldersInfoList,
+      (folderInfo) => new FolderWithPlaceExistenceResDto(folderInfo),
     );
     this.meta = meta;
     this.items = items;

--- a/src/folder/folder.controller.ts
+++ b/src/folder/folder.controller.ts
@@ -6,24 +6,14 @@ import {
   Param,
   Post,
   Put,
-  Query,
   Req,
 } from '@nestjs/common';
 import { FolderService } from './folder.service';
 import { FoldersListResDto } from './dtos/folders-list.res.dto';
 import { CreateFolderReqDto } from './dtos/create-folder-req.dto';
-import { DeletePlacesReqDto } from './dtos/delete-places-req.dto';
-import { MarkersListResDto } from 'src/place/dtos/markers-list-res.dto';
-import {
-  MarkersReqDto,
-  PlacesListReqDto,
-} from 'src/place/dtos/places-list-req.dto';
 import { ApiTags } from '@nestjs/swagger';
-import { CreateFolderPlacesReqDto } from './dtos/create-folder-place-req.dto';
-import { PlacesListResDto } from 'src/place/dtos/paginated-places-list-res.dto';
 import { ApplyDocs } from 'src/common/decorators/apply-docs.decorator';
 import { FolderDocs } from './folder.docs';
-import { UseAccessGuard } from 'src/auth/guards/access.guard';
 import { UseNicknameCheckingAccessGuard } from 'src/auth/guards/nickname-check-access.guard';
 
 @UseNicknameCheckingAccessGuard()
@@ -67,88 +57,8 @@ export class FolderController {
     );
   }
 
-  @Delete('/:folderId/folder-places')
-  async deleteFolderPlaces(
-    @Param('folderId') folderId: number,
-    @Body() deletePlacesReqDto: DeletePlacesReqDto,
-    @Req() req,
-  ) {
-    return await this.folderService.deleteFolderPlaces(
-      req.user.id,
-      folderId,
-      deletePlacesReqDto.placeIds,
-    );
-  }
-
   @Get('/default')
   async getDefaultFolder(@Req() req) {
     return await this.folderService.getDefaultFolder(req.user.id);
-  }
-
-  @Get('/default/markers')
-  async getAllMarkers(
-    @Query() markersReqDto: MarkersReqDto,
-    @Req() req,
-  ): Promise<MarkersListResDto> {
-    return await this.folderService.getMarkers(req.user.id, markersReqDto);
-  }
-
-  @Get('/:folderId/markers')
-  async getMarkersByFolder(
-    @Param('folderId') folderId: number,
-    @Query() markersReqDto: MarkersReqDto,
-    @Req() req,
-  ): Promise<MarkersListResDto> {
-    console.log('controller before method', req.user);
-    return await this.folderService.getMarkers(
-      req.user.id,
-      markersReqDto,
-      folderId,
-    );
-  }
-
-  @Get('/default/places-list')
-  async getAllPlacesList(
-    @Req() req,
-    @Query() placesListReqDto: PlacesListReqDto,
-  ): Promise<PlacesListResDto> {
-    return this.folderService.getPlacesList(req.user.id, placesListReqDto);
-  }
-
-  @Get('/:folderId/places-list')
-  async getPlaceListByFolder(
-    @Req() req,
-    @Param('folderId') folderId: number,
-    @Query() placesListReqDto: PlacesListReqDto,
-  ): Promise<PlacesListResDto> {
-    return this.folderService.getPlacesList(
-      req.user.id,
-      placesListReqDto,
-      folderId,
-    );
-  }
-
-  @Post('/default/folder-places')
-  async createFolderPlacesIntoDefaultFolder(
-    @Body() createFolderPlacesReqDto: CreateFolderPlacesReqDto,
-    @Req() req,
-  ) {
-    return await this.folderService.createFolderPlacesIntoDefaultFolder(
-      req.user.id,
-      createFolderPlacesReqDto,
-    );
-  }
-
-  @Post('/:folderId/folder-places')
-  async createFolderPlacesIntoFolder(
-    @Param('folderId') folderId: number,
-    @Body() createFolderPlacesReqDto: CreateFolderPlacesReqDto,
-    @Req() req,
-  ) {
-    return await this.folderService.createFolderPlacesIntoSpecificFolder(
-      req.user.id,
-      createFolderPlacesReqDto,
-      folderId,
-    );
   }
 }

--- a/src/folder/folder.docs.ts
+++ b/src/folder/folder.docs.ts
@@ -50,90 +50,11 @@ export const FolderDocs: Record<FolderMethodName, MethodDecorator[]> = {
     }),
     ApiIeumExceptionRes(['FOLDER_NOT_FOUND', 'FORBIDDEN_FOLDER']),
   ],
-
-  deleteFolderPlaces: [
-    ApiOperation({
-      summary: '특정 폴더에서 장소 삭제하기',
-      description:
-        '특정 폴더에서 장소를 삭제합니다. 대상 폴더가 디폴트 폴더라면, 모든 폴더에서 해당 장소들을 삭제합니다',
-    }),
-    ApiOkResponse({
-      description: '폴더에서 장소 삭제 성공.',
-    }),
-    ApiIeumExceptionRes(['FOLDER_NOT_FOUND', 'FORBIDDEN_FOLDER']),
-  ],
   getDefaultFolder: [
     ApiOperation({
       summary: '디폴트 폴더 가져오기',
       description: '로그인한 유저의 디폴트 폴더를 가져옵니다(저장한 장소)',
     }),
     ApiOkResponse({ description: '성공', type: FolderResDto }),
-  ],
-  getAllMarkers: [
-    ApiOperation({
-      summary: '저장한 모든 장소의 마커 리스트 가져오기',
-      description: `저장한 모든 장소, 즉 Default Folder에 담겨있는 마커 리스트를 가져옵니다.
-      이음 앱 내에서 사용되는 카테고리인 IeumCategory(FOOD, CAFE, ALCOHOL, MUSEUM, SHOPPING, STAY)에 따라 마커를 필터링하여 가져올 수 있습니다.
-      또한 지역별(서울, 경기, 충북, 충남..)로 마커를 필터링하여 가져올 수 있습니다.`,
-    }),
-    ApiOkResponse({ description: '성공', type: MarkersListResDto }),
-  ],
-  getMarkersByFolder: [
-    ApiOperation({
-      summary: '특정 폴더의 장소 마커 리스트 가져오기',
-      description: `특정 폴더 내의 장소 마커 리스트를 가져옵니다.
-      이음 앱 내에서 사용되는 카테고리인 IeumCategory(FOOD, CAFE, ALCOHOL, MUSEUM, SHOPPING, STAY)에 따라 마커를 필터링하여 가져올 수 있습니다.
-      또한 지역별(서울, 경기, 충북, 충남..)로 마커를 필터링하여 가져올 수 있습니다.`,
-    }),
-    ApiOkResponse({ description: '성공', type: MarkersListResDto }),
-    ApiIeumExceptionRes(['FOLDER_NOT_FOUND', 'FORBIDDEN_FOLDER']),
-  ],
-  getAllPlacesList: [
-    ApiOperation({
-      summary: '저장한 모든 장소 리스트 가져오기',
-      description: `
-      저장한 모든 장소, 즉 Default Folder에 담겨있는 장소 리스트를 가져옵니다.
-      이음 앱 내에서 사용되는 카테고리인 IeumCategory(FOOD, CAFE, ALCOHOL, MUSEUM, SHOPPING, STAY)에 따라 장소를 필터링하여 가져올 수 있습니다.
-      또한 지역별(서울, 경기, 충북, 충남..)로 장소를 필터링하여 가져올 수 있습니다.
-      `,
-    }),
-    ApiOkResponse({ description: '성공', type: PlacesListResDto }),
-  ],
-  getPlaceListByFolder: [
-    ApiOperation({
-      summary: '특정 폴더의 장소 리스트 가져오기',
-      description: `
-      저장한 모든 장소, 즉 Default Folder에 담겨있는 장소 리스트를 가져옵니다.
-      이음 앱 내에서 사용되는 카테고리인 IeumCategory(FOOD, CAFE, ALCOHOL, MUSEUM, SHOPPING, STAY)에 따라 장소를 필터링하여 가져올 수 있습니다.
-      또한 지역별(서울, 경기, 충북, 충남..)로 장소를 필터링하여 가져올 수 있습니다.
-      `,
-    }),
-    ApiOkResponse({ description: '성공', type: PlacesListResDto }),
-    ApiIeumExceptionRes(['FOLDER_NOT_FOUND', 'FORBIDDEN_FOLDER']),
-  ],
-  createFolderPlacesIntoDefaultFolder: [
-    ApiOperation({
-      summary: '디폴트 폴더에 장소 추가하기',
-      description: `
-      폴더를 지정하지 않고, 디폴트 폴더(저장한 장소)에 장소를 추가합니다.
-      해당 장소가 최초로 폴더에 저장된 경우, 장소 상세 정보를 추가적으로 생성합니다.`,
-    }),
-    ApiCreatedResponse({
-      description: '디폴트 폴더에 장소 추가 성공',
-      type: CreateFolderPlaceResDto,
-    }),
-  ],
-  createFolderPlacesIntoFolder: [
-    ApiOperation({
-      summary: '특정 폴더에 장소 추가하기',
-      description: `
-      특정 폴더에 장소를 추가합니다.
-      해당 장소가 최초로 폴더에 저장된 경우, 장소 상세 정보를 추가적으로 생성합니다.`,
-    }),
-    ApiCreatedResponse({
-      description: '특정 폴더에 장소 추가 성공',
-      type: CreateFolderPlaceResDto,
-    }),
-    ApiIeumExceptionRes(['FOLDER_NOT_FOUND', 'FORBIDDEN_FOLDER']),
   ],
 };

--- a/src/folder/folder.module.ts
+++ b/src/folder/folder.module.ts
@@ -16,7 +16,6 @@ import { PlaceModule } from 'src/place/place.module';
   imports: [
     TypeOrmModule.forFeature([Folder, FolderPlace, FolderTag]),
     UserModule,
-    PlaceModule,
   ],
   exports: [FolderService],
 })

--- a/src/folder/folder.service.ts
+++ b/src/folder/folder.service.ts
@@ -10,7 +10,6 @@ import { FolderType } from 'src/common/enums/folder-type.enum';
 
 import { throwIeumException } from 'src/common/utils/exception.util';
 import { Folder } from './entities/folder.entity';
-import { PlaceService } from 'src/place/services/place.service';
 import { FolderInfo } from 'src/common/interfaces/raw-folder-info.interface';
 
 @Injectable()
@@ -20,7 +19,6 @@ export class FolderService {
   constructor(
     private readonly folderRepository: FolderRepository,
     private readonly folderPlaceRepository: FolderPlaceRepository,
-    private readonly placeService: PlaceService,
   ) {}
 
   // ------폴더 관련 메서드------

--- a/src/folder/folder.service.ts
+++ b/src/folder/folder.service.ts
@@ -6,25 +6,12 @@ import {
   FoldersListResDto,
   FoldersWithThumbnailListResDto,
 } from './dtos/folders-list.res.dto';
-import { CreateFolderReqDto } from './dtos/create-folder-req.dto';
 import { FolderType } from 'src/common/enums/folder-type.enum';
-import {
-  MarkerResDto,
-  MarkersListResDto,
-} from 'src/place/dtos/markers-list-res.dto';
-import {
-  MarkersReqDto,
-  PlacesListReqDto,
-} from 'src/place/dtos/places-list-req.dto';
-import { CreateFolderPlacesReqDto } from './dtos/create-folder-place-req.dto';
 
-import { Transactional } from 'typeorm-transactional';
-import { CreateFolderPlaceResDto } from './dtos/create-folder-place-res.dto';
-import { PlacesListResDto } from 'src/place/dtos/paginated-places-list-res.dto';
 import { throwIeumException } from 'src/common/utils/exception.util';
-import { CATEGORIES_MAPPING_KAKAO } from 'src/common/utils/category-mapper.util';
 import { Folder } from './entities/folder.entity';
 import { PlaceService } from 'src/place/services/place.service';
+import { FolderInfo } from 'src/common/interfaces/raw-folder-info.interface';
 
 @Injectable()
 export class FolderService {
@@ -37,6 +24,9 @@ export class FolderService {
   ) {}
 
   // ------폴더 관련 메서드------
+  async getRawFoldersList(userId: number) {
+    return await this.folderRepository.getFoldersList(userId);
+  }
   async getFoldersList(userId: number): Promise<FoldersListResDto> {
     const rawFoldersList = await this.folderRepository.getFoldersList(userId);
     const foldersList = new FoldersListResDto(rawFoldersList);
@@ -64,8 +54,24 @@ export class FolderService {
   }
 
   async getFolderByFolderId(folderId: number): Promise<FolderResDto> {
-    const folder = await this.folderRepository.getFolderByFolderId(folderId);
+    const folder = await this.getRawFolderByFolderId(folderId);
     return new FolderResDto(folder);
+  }
+
+  async getRawFolderByFolderId(folderId: number): Promise<FolderInfo> {
+    return await this.folderRepository.getFolderByFolderId(folderId);
+  }
+
+  async getRawFolderByIdWithCheckingStatus(userId: number, folderId: number) {
+    const folder = await this.folderRepository.getFolderByFolderId(folderId);
+    if (!folder) {
+      throwIeumException('FOLDER_NOT_FOUND');
+    }
+    if (folder.userId !== userId) {
+      throwIeumException('FORBIDDEN_FOLDER');
+    }
+
+    return folder;
   }
 
   async getDefaultFolder(userId: number): Promise<FolderResDto> {
@@ -114,194 +120,47 @@ export class FolderService {
 
   // ------폴더-장소 관련 메서드------
 
-  async getMarkers(
+  async getRawMarkers(
     userId: number,
-    markersReqDto: MarkersReqDto,
+    addressList: string[],
+    kakaoCategoriesForFiltering: string[],
     folderId?: number,
-  ): Promise<MarkersListResDto> {
-    if (folderId) {
-      const folder = await this.folderRepository.getFolderByFolderId(folderId);
-      if (!folder) {
-        throwIeumException('FOLDER_NOT_FOUND');
-      }
-      if (folder.userId !== userId) {
-        throwIeumException('FORBIDDEN_FOLDER');
-      }
-    }
-    const { addressList, categoryList } = markersReqDto;
-    const kakaoCategoriesForFiltering = await Promise.all(
-      categoryList.map(async (category) => {
-        return await this.placeService.getKakaoCategoriesByIeumCategory(
-          category,
-        );
-      }),
-    );
-    const rawMarkersList = await this.folderPlaceRepository.getMarkers(
+  ) {
+    return await this.folderPlaceRepository.getMarkers(
       userId,
       addressList,
-      kakaoCategoriesForFiltering.flat(),
+      kakaoCategoriesForFiltering,
       folderId,
     );
-
-    await Promise.all(
-      rawMarkersList.map(async (marker) => {
-        marker.ieumCategory =
-          await this.placeService.getIeumCategoryByKakaoCategory(
-            marker.primary_category,
-          );
-        return marker; // 이 반환값은 실제로 사용되지 않지만, 명시적으로 표현
-      }),
-    );
-
-    return new MarkersListResDto(rawMarkersList);
   }
 
-  async getPlacesList(
+  async getRawPlacesList(
     userId: number,
-    placesListReqDto: PlacesListReqDto,
+    take: number,
+    addressList: string[],
+    kakaoCategoriesForFiltering: string[],
+    cursorId?: number,
     folderId?: number,
-  ): Promise<PlacesListResDto> {
-    if (folderId) {
-      const folder = await this.folderRepository.getFolderByFolderId(folderId);
-      if (!folder) {
-        throwIeumException('FOLDER_NOT_FOUND');
-      }
-      if (folder.userId !== userId) {
-        throwIeumException('FORBIDDEN_FOLDER');
-      }
-    }
-    const { take, cursorId, addressList, categoryList } = placesListReqDto;
-    const kakaoCategoriesForFiltering = await Promise.all(
-      categoryList.map(async (category) => {
-        return await this.placeService.getKakaoCategoriesByIeumCategory(
-          category,
-        );
-      }),
-    );
-
-    const rawPlacesInfoList = await this.folderPlaceRepository.getPlacesList(
+  ) {
+    return await this.folderPlaceRepository.getPlacesList(
       userId,
       take,
       addressList,
-      kakaoCategoriesForFiltering.flat(),
+      kakaoCategoriesForFiltering,
       cursorId,
       folderId,
     );
-
-    await Promise.all(
-      rawPlacesInfoList.map(async (placeInfo) => {
-        placeInfo.ieumCategory =
-          await this.placeService.getIeumCategoryByKakaoCategory(
-            placeInfo.primary_category,
-          );
-        return placeInfo; // 이 반환값은 실제로 사용되지 않지만, 명시적으로 표현
-      }),
-    );
-    return new PlacesListResDto(rawPlacesInfoList, placesListReqDto.take);
   }
 
-  async createFolderPlacesIntoFolder(
-    //기본 Folder-place 저장 로직
-    userId: number,
-    createFolderPlacesReqDto: CreateFolderPlacesReqDto,
-    folderId: number,
-  ) {
-    const placeIds = createFolderPlacesReqDto.placeIds;
-
-    const folder = await this.folderRepository.getFolderByFolderId(folderId);
-    if (!folder) {
-      throwIeumException('FOLDER_NOT_FOUND');
-    }
-    if (folder.userId !== userId) {
-      throwIeumException('FORBIDDEN_FOLDER');
-    }
-    //placeId에 대한 유효성 체크가 가능한가? -> placeService 주입.
-    //
-    await Promise.all(
-      placeIds.map(async (placeId) => {
-        const place = await this.placeService.getPlaceDetailById(placeId); // 내부에서 유효성 체크 일어난다.
-        if (!place.placeDetail) {
-          // 만약 이 내부에서 fail이 일어나면 어떻게 처리할 것인가?
-          try {
-            await this.placeService.createPlaceDetailByGooglePlacesApi(placeId);
-          } catch (error) {
-            this.logger.error(
-              `Failed to create PlaceDetail By placeId : ${placeId}`,
-            );
-          }
-        }
-        await this.folderPlaceRepository.createFolderPlace(folderId, placeId);
-      }),
-    );
-  }
-
-  @Transactional()
-  async createFolderPlacesIntoDefaultFolder(
-    // Default 폴더에만 저장할 때 호출되는 메서드
-    userId: number,
-    createFolderPlacesReqDto: CreateFolderPlacesReqDto,
-  ): Promise<CreateFolderPlaceResDto> {
-    const defaultFolder = await this.getDefaultFolder(userId);
-    await this.createFolderPlacesIntoFolder(
-      userId,
-      createFolderPlacesReqDto,
-      defaultFolder.id,
-    );
-
-    return new CreateFolderPlaceResDto(createFolderPlacesReqDto.placeIds);
-  }
-
-  @Transactional()
-  async createFolderPlacesIntoSpecificFolder(
-    // 특정 폴더에 저장할 때 호출되는 메서드. default 폴더에도 저장하고, 특정 폴더에도 저장
-    userId: number,
-    createFolderPlacesReqDto: CreateFolderPlacesReqDto,
-    folderId: number,
-  ): Promise<CreateFolderPlaceResDto> {
-    await this.createFolderPlacesIntoDefaultFolder(
-      userId,
-      createFolderPlacesReqDto,
-    );
-    await this.createFolderPlacesIntoFolder(
-      userId,
-      createFolderPlacesReqDto,
+  async createFolderPlace(folderId: number, placeId: number) {
+    return await this.folderPlaceRepository.createFolderPlace(
       folderId,
-    );
-
-    return new CreateFolderPlaceResDto(
-      createFolderPlacesReqDto.placeIds,
-      folderId,
+      placeId,
     );
   }
 
-  @Transactional()
-  async deleteFolderPlaces(
-    userId: number,
-    folderId: number,
-    placeIds: number[],
-  ) {
-    const targetFolder =
-      await this.folderRepository.getFolderByFolderId(folderId);
-    if (!targetFolder) {
-      throwIeumException('FOLDER_NOT_FOUND');
-    }
-    if (targetFolder.userId != userId) {
-      throwIeumException('FORBIDDEN_FOLDER');
-    }
-
-    if (targetFolder.type == FolderType.Default) {
-      //디폴트 폴더라면, 나머지 폴더에서도 전부 삭제
-      const foldersList = await this.folderRepository.getFoldersList(userId);
-      foldersList.forEach(async (folder) => {
-        await this.folderPlaceRepository.deleteFolderPlaces(
-          folder.id,
-          placeIds,
-        );
-      });
-    }
-
+  async deleteFolderPlaces(folderId: number, placeIds: number[]) {
     return await this.folderPlaceRepository.deleteFolderPlaces(
-      //해당 폴더에서 삭제
       folderId,
       placeIds,
     );

--- a/src/folder/folder.service.ts
+++ b/src/folder/folder.service.ts
@@ -22,6 +22,10 @@ export class FolderService {
   ) {}
 
   // ------폴더 관련 메서드------
+  async getAllFoldersList(userId: number): Promise<FolderInfo[]> {
+    return await this.folderRepository.getFoldersList(userId, true);
+  }
+
   async getRawFoldersList(userId: number) {
     return await this.folderRepository.getFoldersList(userId);
   }
@@ -72,6 +76,10 @@ export class FolderService {
     return folder;
   }
 
+  async getRawDefaultFolder(userId: number) {
+    return await this.folderRepository.getDefaultFolder(userId);
+  }
+
   async getDefaultFolder(userId: number): Promise<FolderResDto> {
     const defaultFolder = await this.folderRepository.getDefaultFolder(userId);
     const folderWithFolderPlaces =
@@ -118,6 +126,15 @@ export class FolderService {
 
   // ------폴더-장소 관련 메서드------
 
+  async checkFolderPlaceExistence(
+    folderId: number,
+    placeId: number,
+  ): Promise<boolean> {
+    return await this.folderPlaceRepository.checkFolderPlaceExistence(
+      folderId,
+      placeId,
+    );
+  }
   async getRawMarkers(
     userId: number,
     addressList: string[],

--- a/src/folder/repositories/folder-place.repository.ts
+++ b/src/folder/repositories/folder-place.repository.ts
@@ -12,6 +12,16 @@ export class FolderPlaceRepository extends Repository<FolderPlace> {
     super(FolderPlace, dataSource.createEntityManager());
   }
 
+  async checkFolderPlaceExistence(
+    folderId: number,
+    placeId: number,
+  ): Promise<boolean> {
+    const folderPlace = await this.findOne({
+      where: { folderId: folderId, placeId: placeId },
+    });
+    return !!folderPlace;
+  }
+
   async getFolderThumbnail(folderId: number): Promise<string> {
     const result = await this.createQueryBuilder('folderPlace')
       .leftJoin('folderPlace.place', 'place')

--- a/src/place-complex/place-complex.controller.ts
+++ b/src/place-complex/place-complex.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('place-complex')
+export class PlaceComplexController {}

--- a/src/place-complex/place-complex.controller.ts
+++ b/src/place-complex/place-complex.controller.ts
@@ -22,4 +22,16 @@ export class PlaceComplexController {
       parseInt(placeId),
     );
   }
+
+  @UseNicknameCheckingAccessGuard()
+  @Get('/:placeId/folders')
+  async getFoldersListWithPlaceExistence(
+    @Req() req,
+    @Param('placeId') placeId: string,
+  ) {
+    return await this.placeComplexService.getFoldersListWithPlaceExistence(
+      req.user.id,
+      parseInt(placeId),
+    );
+  }
 }

--- a/src/place-complex/place-complex.controller.ts
+++ b/src/place-complex/place-complex.controller.ts
@@ -1,4 +1,25 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Param, Req } from '@nestjs/common';
+import { PlaceComplexService } from './place-complex.service';
+import { UseNicknameCheckingAccessGuard } from 'src/auth/guards/nickname-check-access.guard';
+import { ApiTags } from '@nestjs/swagger';
+import { ApplyDocs } from 'src/common/decorators/apply-docs.decorator';
+import { PlaceComplexDocs } from './place-complex.docs';
 
-@Controller('place-complex')
-export class PlaceComplexController {}
+@ApplyDocs(PlaceComplexDocs)
+@ApiTags('장소 API')
+@Controller('places')
+export class PlaceComplexController {
+  constructor(private readonly placeComplexService: PlaceComplexService) {}
+
+  @UseNicknameCheckingAccessGuard()
+  @Get('/:placeId')
+  async getPlaceDetailWithImagesAndCollectionsById(
+    @Req() req,
+    @Param('placeId') placeId: string,
+  ) {
+    return await this.placeComplexService.getPlaceDetailWithImagesAndCollectionsById(
+      req.user.id,
+      parseInt(placeId),
+    );
+  }
+}

--- a/src/place-complex/place-complex.docs.ts
+++ b/src/place-complex/place-complex.docs.ts
@@ -1,0 +1,21 @@
+import { MethodNames } from 'src/common/types/method-names.type';
+import { ApiOkResponse, ApiOperation } from '@nestjs/swagger';
+import { ApiIeumExceptionRes } from 'src/common/decorators/api-ieum-exception-res.decorator';
+import { PlaceDetailResDto } from 'src/place/dtos/place-detail-res.dto';
+import { PlaceComplexController } from './place-complex.controller';
+
+type PlaceComplexMethodName = MethodNames<PlaceComplexController>;
+
+export const PlaceComplexDocs: Record<
+  PlaceComplexMethodName,
+  MethodDecorator[]
+> = {
+  getPlaceDetailWithImagesAndCollectionsById: [
+    ApiOperation({ summary: '특정 장소의 상세 정보 조회' }),
+    ApiOkResponse({
+      description: '상세 정보 조회 성공',
+      type: PlaceDetailResDto,
+    }),
+    ApiIeumExceptionRes(['PLACE_NOT_FOUND']),
+  ],
+};

--- a/src/place-complex/place-complex.docs.ts
+++ b/src/place-complex/place-complex.docs.ts
@@ -3,6 +3,7 @@ import { ApiOkResponse, ApiOperation } from '@nestjs/swagger';
 import { ApiIeumExceptionRes } from 'src/common/decorators/api-ieum-exception-res.decorator';
 import { PlaceDetailResDto } from 'src/place/dtos/place-detail-res.dto';
 import { PlaceComplexController } from './place-complex.controller';
+import { FoldersWithPlaceExistenceListResDto } from 'src/folder/dtos/folders-list.res.dto';
 
 type PlaceComplexMethodName = MethodNames<PlaceComplexController>;
 
@@ -15,6 +16,19 @@ export const PlaceComplexDocs: Record<
     ApiOkResponse({
       description: '상세 정보 조회 성공',
       type: PlaceDetailResDto,
+    }),
+    ApiIeumExceptionRes(['PLACE_NOT_FOUND']),
+  ],
+  getFoldersListWithPlaceExistence: [
+    ApiOperation({
+      summary:
+        '특정 장소를 포함하고 있는지의 여부를 담은 폴더 리스트를 조회합니다.',
+      description:
+        '특정 장소를 포함하고 있는지의 여부를 담은 폴더 리스트를 조회합니다.',
+    }),
+    ApiOkResponse({
+      description: '폴더 리스트 조회 성공',
+      type: [FoldersWithPlaceExistenceListResDto],
     }),
     ApiIeumExceptionRes(['PLACE_NOT_FOUND']),
   ],

--- a/src/place-complex/place-complex.module.ts
+++ b/src/place-complex/place-complex.module.ts
@@ -1,9 +1,13 @@
 import { Module } from '@nestjs/common';
 import { PlaceComplexController } from './place-complex.controller';
 import { PlaceComplexService } from './place-complex.service';
+import { PlaceModule } from 'src/place/place.module';
+import { UserModule } from 'src/user/user.module';
+import { CollectionModule } from 'src/collection/collection.module';
 
 @Module({
+  imports: [PlaceModule, CollectionModule, UserModule],
   controllers: [PlaceComplexController],
-  providers: [PlaceComplexService]
+  providers: [PlaceComplexService],
 })
 export class PlaceComplexModule {}

--- a/src/place-complex/place-complex.module.ts
+++ b/src/place-complex/place-complex.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { PlaceComplexController } from './place-complex.controller';
+import { PlaceComplexService } from './place-complex.service';
+
+@Module({
+  controllers: [PlaceComplexController],
+  providers: [PlaceComplexService]
+})
+export class PlaceComplexModule {}

--- a/src/place-complex/place-complex.module.ts
+++ b/src/place-complex/place-complex.module.ts
@@ -4,9 +4,10 @@ import { PlaceComplexService } from './place-complex.service';
 import { PlaceModule } from 'src/place/place.module';
 import { UserModule } from 'src/user/user.module';
 import { CollectionModule } from 'src/collection/collection.module';
+import { FolderModule } from 'src/folder/folder.module';
 
 @Module({
-  imports: [PlaceModule, CollectionModule, UserModule],
+  imports: [PlaceModule, CollectionModule, FolderModule, UserModule],
   controllers: [PlaceComplexController],
   providers: [PlaceComplexService],
 })

--- a/src/place-complex/place-complex.service.ts
+++ b/src/place-complex/place-complex.service.ts
@@ -1,4 +1,35 @@
 import { Injectable } from '@nestjs/common';
+import { CollectionService } from 'src/collection/collection.service';
+import { PlaceDetailResDto } from 'src/place/dtos/place-detail-res.dto';
+import { PlaceService } from 'src/place/services/place.service';
+import { UserService } from 'src/user/user.service';
 
 @Injectable()
-export class PlaceComplexService {}
+export class PlaceComplexService {
+  constructor(
+    private readonly placeService: PlaceService,
+    private readonly collectionService: CollectionService,
+  ) {}
+
+  async getPlaceDetailWithImagesAndCollectionsById(
+    userId: number,
+    placeId: number,
+  ): Promise<PlaceDetailResDto> {
+    const placeDetail = await this.placeService.getPlaceDetailById(placeId);
+    const placeImages =
+      await this.placeService.getPlaceImagesByPlaceId(placeId);
+    const linkedCollections = await this.collectionService.getLinkedCollections(
+      userId,
+      placeId,
+    );
+    const ieumCategory = await this.placeService.getIeumCategoryByKakaoCategory(
+      placeDetail.primaryCategory,
+    );
+    return new PlaceDetailResDto(
+      placeDetail,
+      placeImages,
+      linkedCollections,
+      ieumCategory,
+    );
+  }
+}

--- a/src/place-complex/place-complex.service.ts
+++ b/src/place-complex/place-complex.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class PlaceComplexService {}

--- a/src/place/controllers/place.controller.ts
+++ b/src/place/controllers/place.controller.ts
@@ -63,18 +63,6 @@ export class PlaceController {
   //   return await this.placeService.getGooglePlacesApiPlaceDetailsById(placeId);
   // }
 
-  @UseNicknameCheckingAccessGuard()
-  @Get('/:placeId')
-  async getPlaceDetailWithImagesAndCollectionsById(
-    @Req() req,
-    @Param('placeId') placeId: string,
-  ) {
-    return await this.placeService.getPlaceDetailWithImagesAndCollectionsById(
-      req.user.id,
-      parseInt(placeId),
-    );
-  }
-
   @Post('/:placeId/detail')
   async createPlaceDetailByGoogle(@Param('placeId') placeId: string) {
     return await this.placeService.createPlaceDetailByGooglePlacesApi(

--- a/src/place/docs/place.docs.ts
+++ b/src/place/docs/place.docs.ts
@@ -20,14 +20,6 @@ export const PlaceDocs: Record<PlaceMethodName, MethodDecorator[]> = {
     ApiOperation({ summary: '장소명으로 DB 내의 장소 검색' }),
     ApiQuery({ name: 'placeName', type: 'string' }),
   ],
-  getPlaceDetailWithImagesAndCollectionsById: [
-    ApiOperation({ summary: '특정 장소의 상세 정보 조회' }),
-    ApiOkResponse({
-      description: '상세 정보 조회 성공',
-      type: PlaceDetailResDto,
-    }),
-    ApiIeumExceptionRes(['PLACE_NOT_FOUND']),
-  ],
   getPlacePreviewInfoById: [
     ApiOperation({ summary: '특정 장소의 프리뷰 검색' }),
     ApiOkResponse({

--- a/src/place/repositories/place.repository.ts
+++ b/src/place/repositories/place.repository.ts
@@ -10,6 +10,11 @@ export class PlaceRepository extends Repository<Place> {
   }
 
   // ---------장소 검색---------
+  async getPlaceByPlaceId(placeId: number): Promise<Place> {
+    return await this.createQueryBuilder('place')
+      .where('place.id = :placeId', { placeId })
+      .getOne();
+  }
   async getPlaceDetailById(placeId: number): Promise<Place> {
     return await this.createQueryBuilder('place')
       .leftJoinAndSelect('place.placeDetail', 'placeDetail')

--- a/src/place/services/place.service.ts
+++ b/src/place/services/place.service.ts
@@ -10,7 +10,6 @@ import { PlaceRepository } from 'src/place/repositories/place.repository';
 import { PlaceImageRepository } from 'src/place/repositories/place-image.repository';
 import { Transactional } from 'typeorm-transactional';
 import { PlacePreviewResDto } from '../dtos/place-preview-res.dto';
-import { PlaceDetailResDto } from '../dtos/place-detail-res.dto';
 import { TagService } from 'src/tag/tag.service';
 import { TagType } from 'src/common/enums/tag-type.enum';
 import { S3Service } from 'src/place/services/s3.service';
@@ -21,8 +20,6 @@ import { Place } from '../entities/place.entity';
 import { throwIeumException } from 'src/common/utils/exception.util';
 import { addressSimplifier } from 'src/common/utils/address-simplifier.util';
 import { GooglePlacesApiPlaceDetailsRes } from 'src/common/interfaces/google-places-api.interface';
-import { CollectionService } from 'src/collection/collection.service';
-import { RawLinkedColletion } from 'src/common/interfaces/raw-linked-collection.interface';
 import { KakaoCategoryMappingService } from './kakao-category-mapping.service';
 import { IeumCategory } from 'src/common/enums/ieum-category.enum';
 
@@ -33,7 +30,6 @@ export class PlaceService {
     private readonly placeTagRepository: PlaceTagRepository,
     private readonly placeImageRepository: PlaceImageRepository,
     private readonly placeDetailRepository: PlaceDetailRepository,
-    private readonly collectionService: CollectionService,
     private readonly tagService: TagService,
     private readonly s3Service: S3Service,
     private readonly kakaoCategoryMappingService: KakaoCategoryMappingService,
@@ -137,6 +133,9 @@ export class PlaceService {
       placeDetailsForTransferring,
     );
   }
+  async getPlaceImagesByPlaceId(placeId: number) {
+    return await this.placeImageRepository.getPlaceImagesByPlaceId(placeId);
+  }
 
   async uploadImageToS3ByUri(photoUri: string) {
     return await this.s3Service.getAndUploadFromUri(photoUri);
@@ -176,28 +175,6 @@ export class PlaceService {
       throwIeumException('PLACE_NOT_FOUND');
     }
     return placeDetail;
-  }
-
-  async getPlaceDetailWithImagesAndCollectionsById(
-    userId: number,
-    placeId: number,
-  ): Promise<PlaceDetailResDto> {
-    const placeDetail = await this.getPlaceDetailById(placeId);
-    const placeImages =
-      await this.placeImageRepository.getPlaceImagesByPlaceId(placeId);
-    const linkedCollections = await this.collectionService.getLinkedCollections(
-      userId,
-      placeId,
-    );
-    const ieumCategory = await this.getIeumCategoryByKakaoCategory(
-      placeDetail.primaryCategory,
-    );
-    return new PlaceDetailResDto(
-      placeDetail,
-      placeImages,
-      linkedCollections,
-      ieumCategory,
-    );
   }
 
   async getPlacePreviewInfoById(placeId: number): Promise<PlacePreviewResDto> {

--- a/src/place/services/place.service.ts
+++ b/src/place/services/place.service.ts
@@ -169,6 +169,15 @@ export class PlaceService {
   }
 
   // ---------내부 DB 검색---------
+  async getPlaceByIdWithCheckingStatus(placeId: number) {
+    const place = await this.placeRepository.getPlaceByPlaceId(placeId);
+    if (!place) {
+      throwIeumException('PLACE_NOT_FOUND');
+    }
+
+    return place;
+  }
+
   async getPlaceDetailById(placeId: number): Promise<Place> {
     const placeDetail = await this.placeRepository.getPlaceDetailById(placeId);
     if (!placeDetail) {


### PR DESCRIPTION
## Description 
새로운 요구사항에 따라, 특정 장소를 포함하는 폴더 리스트를 얻을 수 있는 API를 구현하려 하였습니다.

그러나 이 과정에서 기존 아키텍처 상의 문제가 발견되었는데, 다음과 같습니다. :

의미적으로 상하관계에 있는 모듈이 아님에도, 
placeService가 collectionService 주입받아 비즈니스 로직을 구현하였고, folderService는 placeService 주입받아서 비즈니스 로직을 구현하고 있었습니다. collectionService → placeService → folderService라는 의존 관계가 발생하였습니다.

새로운 기능은 place 도메인에서 실행되지만, folderService가 있어야 구현이 가능하므로 순환 참조 문제가 생길 가능성이 다분하게 보였습니다.

이러한 관점에서 계속해서 모듈 간의 독립성이 보장되지 못해 순환 참조 문제가 생길 것으로 예상하였고, API를 구현하기에 앞서 아키텍처 상의 문제점을 개선하고자 하였습니다.

명확히 상하관계로 정의되어 있는 도메인이 아니라면, 직접 주입받아 사용하지 않도록 하였습니다.
예를 들어, placeImage, placeDetail과 같은 도메인은 place라는 도메인의 완전한 하위 도메인이므로 placeService에서 해당 엔터티를 접근하여 로직을 작성할 수 있지만,
place, folder, collection 각각은 상하관계로 묶인 도메인이 아닌, 독립성이 보장되어야 하는 도메인들입니다.

따라서 이 도메인들의 서비스를 복합적으로 이용하여 비즈니스 로직을 작성하여야 하는 경우는, 어느 한 도메인의 서비스에서 다른 도메인의 서비스를 직접 주입받아 사용하지 않고, 중재자 패턴을 이용하여 중간 계층에서 다른 서비스들을 주입받아 사용함으로써 직접적인 의존 관계를 피했습니다.

복합적인 서비스 메서드를 사용하여 생성된 비즈니스 로직이어도, 사용되는 맥락 자체는 어느 한 도메인에 속해있다고 볼 수 있기 때문에, 맥락에 따라 중재자 모듈을 분리하였습니다(place-complex, folder-complex, collection-complex). 

이와 같이 아키텍처를 개선한 후에, place-complex 모듈에 원래 요구사항이었던 API를 작성하였습니다.
GET /places/:placeId/folders로 해당 API를 호출할 수 있으며, 유저의 모든 폴더 리스트(디폴트 폴더)를 반환하되, 파라미터에 포함한 특정 장소를 포함하고 있는지에 대한 여부를 placeExistence : boolean 필드를 통해 표시하였습니다.

## To Discuss
x

## Test
로컬 테스트 결과 정상적으로 작동하는 것으로 확인되었습니다.
collection, folder, place API들에 대해 정상 작동하지 않는 경우 Slack으로 알려주세요.

## ETC
x

## Related Issues
x
