### PR TITLE
fix : 장소를 폴더에 저장할 시에 is_Saved를 업데이트하도록 수정

### DIFF
--- a/src/collection/collection.service.ts
+++ b/src/collection/collection.service.ts
@@ -134,4 +134,18 @@ export class CollectionService {
       placeKeyword,
     );
   }
+
+  async updateCollectionPlacesIsSavedToTrue(
+    collectionId: number,
+    placeIds: number[],
+  ): Promise<void> {
+    await Promise.all(
+      placeIds.map(async (placeId) => {
+        await this.collectionPlaceRepository.updateCollectionPlaceIsSavedToTrue(
+          collectionId,
+          placeId,
+        );
+      }),
+    );
+  }
 }

--- a/src/collection/repositories/collection-place.repository.ts
+++ b/src/collection/repositories/collection-place.repository.ts
@@ -47,4 +47,16 @@ export class CollectionPlaceRepository extends Repository<CollectionPlace> {
       placeKeyword: placeKeyword,
     });
   }
+
+  async updateCollectionPlaceIsSavedToTrue(
+    collectionId: number,
+    placeId: number,
+  ) {
+    const collectionPlace = await this.findOne({
+      where: { collectionId, placeId },
+    });
+
+    collectionPlace.isSaved = true;
+    await this.save(collectionPlace);
+  }
 }

--- a/src/folder-complex/folder-complex.module.ts
+++ b/src/folder-complex/folder-complex.module.ts
@@ -4,9 +4,10 @@ import { FolderComplexService } from './folder-complex.service';
 import { FolderModule } from 'src/folder/folder.module';
 import { PlaceModule } from 'src/place/place.module';
 import { UserModule } from 'src/user/user.module';
+import { CollectionModule } from 'src/collection/collection.module';
 
 @Module({
-  imports: [FolderModule, PlaceModule, UserModule],
+  imports: [FolderModule, PlaceModule, UserModule, CollectionModule],
   controllers: [FolderComplexController],
   providers: [FolderComplexService],
 })

--- a/src/folder-complex/folder-complex.service.ts
+++ b/src/folder-complex/folder-complex.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { CollectionService } from 'src/collection/collection.service';
 import { FolderType } from 'src/common/enums/folder-type.enum';
 import { CreateFolderPlaceEvent } from 'src/common/events/create-folder-place-event';
 import { throwIeumException } from 'src/common/utils/exception.util';
@@ -21,6 +22,7 @@ export class FolderComplexService {
   constructor(
     private readonly folderService: FolderService,
     private readonly placeService: PlaceService,
+    private readonly collectionService: CollectionService,
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
@@ -141,7 +143,12 @@ export class FolderComplexService {
       createFolderPlacesReqDto,
       defaultFolder.id,
     );
-    // 여기서
+    // 여기서 collection_place의 is_saved를 업데이트
+    const { collectionId, placeIds } = createFolderPlacesReqDto;
+    await this.collectionService.updateCollectionPlacesIsSavedToTrue(
+      collectionId,
+      placeIds,
+    );
 
     return new CreateFolderPlaceResDto(createFolderPlacesReqDto.placeIds);
   }

--- a/src/folder/dtos/create-folder-place-req.dto.ts
+++ b/src/folder/dtos/create-folder-place-req.dto.ts
@@ -1,6 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateFolderPlacesReqDto {
+  @ApiProperty()
+  collectionId: number;
+
   @ApiProperty({ type: [Number] })
   placeIds: number[];
 }


### PR DESCRIPTION
## Description 
- 장소를 저장했음에도 장소 후보 리스트에서 저장한 장소가 0개로 표시되는 에러를 수정한 커밋입니다.
- 장소 후보 리스트에서 장소를 저장했음을 저장하기 위해, 이제 장소를 폴더에 저장할 때 어떤 collection(게시글)에서 저장한 것인지에 대한 정보를 제공해야 합니다(collectionId) 하단 스크린샷의 요청 명세 참고해주세요.
- 디폴트 폴더 저장과, 일반 폴더 저장 모두 수정되어야 합니다.

## To Discuss


## Test


## ETC
이전 장소 저장 API 
![image](https://github.com/user-attachments/assets/c3202d3c-d968-4bb2-b9bf-42f9edf4cd37)

이후 장소 저장 API
![image](https://github.com/user-attachments/assets/01258d8c-a7ac-403e-92bb-3626045803a5)

## Related Issues

