### PR TITLE
슬랙 알림 (회원가입)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -88,6 +88,7 @@ jobs:
           echo "SECRET_KEY_ACCESS=${{ secrets.SECRET_KEY_ACCESS}}" >> .env
           echo "SECRET_KEY_REFRESH=${{ secrets.SECRET_KEY_REFRESH}}" >> .env
           echo "WEBHOOK_URL=${{ secrets.WEBHOOK_URL}}" >> .env
+          echo "WEBHOOK_URL_GENERAL_NOTIFICATION=${{ secrets.WEBHOOK_URL_GENERAL_NOTIFICATION}}" >> .env
           echo "RABBITMQ_URI=${{ secrets.RABBITMQ_URI}}" >> .env
           echo "KAKAO_REST_API_KEY=${{ secrets.KAKAO_REST_API_KEY}}" >> .env
           echo "AWS_REGION=${{ secrets.AWS_REGION}}" >> .env

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "config": "^3.3.11",
         "cors": "^2.8.5",
         "csv-parse": "^5.5.5",
+        "event-emitter": "^0.3.5",
         "firebase-admin": "^12.4.0",
         "jsonwebtoken": "^9.0.2",
         "jwks-rsa": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "config": "^3.3.11",
     "cors": "^2.8.5",
     "csv-parse": "^5.5.5",
+    "event-emitter": "^0.3.5",
     "firebase-admin": "^12.4.0",
     "jsonwebtoken": "^9.0.2",
     "jwks-rsa": "^3.1.0",

--- a/src/auth/auth.docs.ts
+++ b/src/auth/auth.docs.ts
@@ -39,6 +39,7 @@ export const AuthDocs: Record<AuthMethodName, MethodDecorator[]> = {
       'APPLE_ID_TOKEN_VERIFICATION_FAILED',
       'KAKAO_ACCESS_TOKEN_VERIFICATION_FAILED',
       'NAVER_ACCESS_TOKEN_VERIFICATION_FAILED',
+      //'SLACK_NOTIFICATION_FAILED',
     ]),
   ],
   handleAppleNotification: [

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -4,12 +4,13 @@ import { AuthService } from './auth.service';
 import { JwtModule } from '@nestjs/jwt';
 import { UserModule } from 'src/user/user.module';
 import { NicknameCheckingAccessGuard } from './guards/nickname-check-access.guard';
+import { SlackAlertService } from 'src/crawling/services/slack-alert.service';
 
 @Global()
 @Module({
   imports: [UserModule, JwtModule.register({})],
   controllers: [AuthController],
-  providers: [AuthService],
+  providers: [AuthService, SlackAlertService],
   exports: [JwtModule],
 })
 export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -20,6 +20,7 @@ import { KakaoAccessTokenData } from 'src/common/interfaces/kakao-jwt-format.int
 import { NaverAccessTokenData } from 'src/common/interfaces/naver-jwt-format.interface';
 import { User } from 'src/user/entities/user.entity';
 import { throwIeumException } from 'src/common/utils/exception.util';
+import { SlackAlertService } from 'src/crawling/services/slack-alert.service';
 
 @Injectable()
 export class AuthService {
@@ -33,6 +34,7 @@ export class AuthService {
   constructor(
     private readonly jwtService: JwtService,
     private readonly userService: UserService,
+    private readonly slackAlertService: SlackAlertService,
   ) {}
 
   //AccessToken 발급
@@ -130,6 +132,11 @@ export class AuthService {
     if (fcmToken) {
       await this.userService.updateFCMToken(user.id, fcmToken);
     }
+    await this.slackAlertService.sendGeneralSlackNotification(
+      newUser,
+      '유저 정보',
+      '새로운 유저 ${user.id}의 회원가입 알람 입니다.',
+    );
     return new UserLoginResDto(newUser, accessToken, refreshToken);
   }
 

--- a/src/crawling/dtos/slack-failure-res.dto.ts
+++ b/src/crawling/dtos/slack-failure-res.dto.ts
@@ -1,0 +1,21 @@
+import { AxiosError } from 'axios';
+
+export class SlackFailureResDto {
+  readonly message: string;
+  readonly timestamp: string; // 에러 발생 시간
+  readonly errorCode: string; // 에러 코드
+  readonly errorMessage: string; // 에러 메시지
+  readonly url: string; // 요청 웹훅 URL
+  readonly method: string; // HTTP 요청 메서드
+  readonly requestPayload?: any; // 요청 데이터
+
+  constructor(error: AxiosError) {
+    this.message = 'Slack General Notification 발송 실패.';
+    this.timestamp = new Date().toISOString(); // 현재 시간
+    this.errorCode = error.code;
+    this.errorMessage = error.message; // 에러 메시지
+    this.url = error.config.url; // 요청 웹훅 URL
+    this.method = error.config.method; // HTTP 메서드
+    this.requestPayload = error.config?.data; // 요청 데이터
+  }
+}

--- a/src/crawling/services/slack-alert.service.ts
+++ b/src/crawling/services/slack-alert.service.ts
@@ -38,4 +38,38 @@ export class SlackAlertService {
       throwIeumException('SLACK_NOTIFICATION_FAILED');
     }
   }
+
+  async sendGeneralSlackNotification(
+    data: any,
+    dataDescription: string,
+    title: string,
+  ) {
+    const payload = {
+      text: `💁‍♂️ ${title}`,
+      attachments: [
+        {
+          color: '#0000FF',
+          fields: [
+            {
+              title: dataDescription,
+              value: '```' + JSON.stringify(data, null, 2) + '```',
+            },
+          ],
+        },
+      ],
+    };
+    try {
+      await axios.post(process.env.WEBHOOK_URL_GENERAL_NOTIFICATION, payload);
+    } catch (error) {
+      console.error(
+        'Failed to send Slack alert:',
+        error.response.status,
+        error.response.statusText,
+        error.response.data,
+      );
+      //큐 기반 동작을 통해 slack 알림 실패와 상관없이 메인 서비스 기능이 정상적으로 돌아갈 수 있을 때 활성화.
+      //현재는 slack 알림이 실패해도 메인 서비스 기능에 영향을 주지 않도록 비활성화 함.
+      //throwIeumException('SLACK_NOTIFICATION_FAILED');
+    }
+  }
 }


### PR DESCRIPTION
## Description 

현재는 회원가입 시 슬랙에 알람을 주는 기능만 활성화 했는데, 이후 다른 기능 동작 시에도 슬랙에 알람을 줄 수 있도록 공통적으로 쓸 sendGeneralSlackNotification 함수를 만들었습니다. 

data: any = 알람에 노출시킬 데이터
dataDescription: string = 데이터에 대한 설명 
title: string = 알람의 제목

슬랙 알림에 실패 했을 때, 메인 서비스의 작동을 방해하지 않도록 error를 throw하지 않고,  AxiosError를 받아 SlackFailureResDto로 formatting한 후 error level log를 winstonLogger를 통해 남겨, alertmanager를 통해 알람이 오도록 했습니다. 

## To Discuss

X

## Test
![image](https://github.com/user-attachments/assets/9e703f68-61fb-4389-8411-1cc0928c6b99)

## ETC
X

## Related Issues
X
